### PR TITLE
fix: Implement comprehensive tab selection strategy and browser tab management

### DIFF
--- a/bykilt.py
+++ b/bykilt.py
@@ -293,7 +293,7 @@ def create_ui(config, theme_name="Ocean"):
                     # Add tab selection strategy control
                     tab_selection_strategy = gr.Radio(
                         choices=["new_tab", "active_tab", "last_tab"],
-                        value="new_tab",
+                        value="active_tab",
                         label="Tab Selection Strategy",
                         info="Choose which browser tab to use for automation when using own browser",
                         visible=True

--- a/llms.txt
+++ b/llms.txt
@@ -81,6 +81,7 @@ actions:
 
   - name: search-jsonpayload
     type: unlock-future
+    keep_tab_open: true
     params:
       - name: query
         required: true
@@ -101,14 +102,30 @@ actions:
 
   - name: click-jsonpayload
     type: unlock-future
+    tab_selection_strategy: active_tab  # Explicitly specify active_tab
+    keep_tab_open: true
     flow:
       - action: keyboard_press
         key: "Enter"
 
   - name: nogtips-jsonpayload
-    type: browser-control
+    type: unlock-future
+    keep_tab_open: True
+    tab_selection_strategy: new_tab  # 明示的に新規タブを指定
+    params:
+      - name: query
+        required: true
+        type: string
+        description: "Search query to execute"
     slowmo: 1000
     flow:
       - action: command
         url: "https://nogtips.wordpress.com/"
         wait_until: "domcontentloaded"
+      - action: click
+        selector: "#eu-cookie-law > form > input"
+      - action: click
+        selector: "#search-2 > form > label > input"
+      - action: fill_form
+        selector: "#search-2 > form > label > input"
+        value: "${params.query}"

--- a/src/agent/agent_manager.py
+++ b/src/agent/agent_manager.py
@@ -262,7 +262,7 @@ async def run_browser_agent(
     use_own_browser, keep_browser_open, headless, disable_security, window_w, window_h,
     save_recording_path, save_agent_history_path, save_trace_path, enable_recording, task, add_infos,
     max_steps, use_vision, max_actions_per_step, tool_calling_method, maintain_browser_session=False,
-    tab_selection_strategy="new_tab"  # Add parameter with default
+    tab_selection_strategy="active_tab"  # Add parameter with default
 ):
     """
     Main function to run browser agent based on specified parameters
@@ -292,7 +292,7 @@ async def run_browser_agent(
         max_actions_per_step: Maximum number of actions per step
         tool_calling_method: Method for calling tools
         maintain_browser_session: Whether to maintain the browser session between tasks
-        tab_selection_strategy: Strategy for tab selection ("new_tab", "active_tab", or "last_tab")
+        tab_selection_strategy: Strategy for tab selection ("active_tab", "new_tab" or "last_tab")
     """
     # Get agent state from globals
     globals_dict = get_globals()

--- a/src/config/action_translator.py
+++ b/src/config/action_translator.py
@@ -40,7 +40,9 @@ class ActionTranslator:
         json_commands = {
             "commands": [],
             "maintain_session": maintain_session,
-            "tab_selection_strategy": tab_selection_strategy  # Add tab selection strategy
+            "tab_selection_strategy": tab_selection_strategy,  # Include tab selection strategy
+            "keep_tab_open": action_def.get("keep_tab_open", False),
+            "slowmo": action_def.get("slowmo", 1000)
         }
         
         if action_def.get('type') in ['browser-control', 'unlock-future']:

--- a/src/modules/direct_browser_control.py
+++ b/src/modules/direct_browser_control.py
@@ -1,0 +1,159 @@
+import asyncio
+import logging
+from typing import Dict, Any, List
+import json
+from src.browser.browser_debug_manager import BrowserDebugManager
+from src.utils.debug_utils import DebugUtils
+
+logger = logging.getLogger(__name__)
+
+async def convert_flow_to_commands(flow: List[Dict[str, Any]], params: Dict[str, Any]) -> List[Dict[str, Any]]:
+    """Convert YAML flow actions to commands format for direct execution"""
+    commands = []
+    for step in flow:
+        action_type = step.get('action')
+        processed_step = {}
+        for key, value in step.items():
+            if isinstance(value, str) and '{' in value:
+                for param_name, param_value in params.items():
+                    placeholder = f"${{params.{param_name}}}"
+                    if placeholder in value:
+                        value = value.replace(placeholder, str(param_value))
+            processed_step[key] = value
+
+        cmd = {"action": None, "args": []}
+        if action_type == "command" and "url" in processed_step:
+            cmd["action"] = "go_to_url"
+            cmd["args"] = [processed_step["url"]]
+        elif action_type == "click":
+            cmd["action"] = "click_element"
+            cmd["args"] = [processed_step["selector"]]
+        elif action_type == "fill_form":
+            cmd["action"] = "input_text"
+            cmd["args"] = [processed_step["selector"], processed_step["value"]]
+        elif action_type == "keyboard_press":
+            cmd["action"] = "keyboard_press"
+            cmd["args"] = [processed_step["selector"]]
+        elif action_type == "wait_for_navigation":
+            cmd["action"] = "wait_for_navigation"
+            cmd["args"] = []
+        elif action_type == "wait_for":
+            cmd["action"] = "wait_for_element"
+            cmd["args"] = [processed_step["selector"]]
+        elif action_type == "extract_text":
+            cmd["action"] = "extract_content"
+            cmd["args"] = [processed_step.get("selector", None)]
+        elif action_type == "screenshot":
+            cmd["action"] = "screenshot"
+            cmd["args"] = [processed_step.get("path", "screenshot.png")]
+        else:
+            logger.warning(f"Unsupported action type: {action_type}")
+            continue
+        commands.append(cmd)
+    return commands
+
+async def execute_direct_browser_control(action: Dict[str, Any], **params) -> bool:
+    """Execute browser control directly using modular components"""
+    logger.info(f"Executing direct browser control for action: {action['name']}")
+    try:
+        flow = action.get('flow', [])
+        use_own_browser = params.get('use_own_browser', False)
+        headless = params.get('headless', False)
+        
+        # Convert flow to command format
+        commands = await convert_flow_to_commands(flow, params)
+        logger.info(f"Converted flow to {len(commands)} commands: {json.dumps(commands)}")
+        
+        # Use BrowserDebugManager and DebugUtils directly
+        browser_manager = BrowserDebugManager()
+        debug_utils = DebugUtils()
+        debug_utils.browser_manager = browser_manager
+        
+        # Execute commands
+        await execute_commands(commands, browser_manager, use_own_browser, headless)
+        
+        logger.info(f"Successfully executed direct browser control for action: {action['name']}")
+        return True
+    except Exception as e:
+        logger.error(f"Error executing direct browser control: {e}")
+        import traceback
+        logger.error(traceback.format_exc())
+        return False
+
+async def execute_commands(commands, browser_manager, use_own_browser=False, headless=False):
+    """Execute a list of commands in the browser using BrowserDebugManager"""
+    logger.info("\nExecuting commands:")
+    for i, cmd in enumerate(commands, 1):
+        logger.info(f" {i}. {cmd['action']}: {cmd.get('args', [])}")
+
+    try:
+        browser_data = await browser_manager.initialize_custom_browser(use_own_browser, headless)
+        browser = browser_data["browser"]
+        
+        # Use the default context for CDP browsers
+        if browser_data.get("is_cdp", False):
+            context = browser.contexts[0] if browser.contexts else await browser.new_context()
+            logger.info("Using existing Chrome window to create a new tab")
+        else:
+            context = browser_data.get("context") or await browser.new_context()
+        
+        # Create a new tab in the context
+        page = await context.new_page()
+        
+        # Add element indexing for debugging
+        debug_utils = DebugUtils()
+        await debug_utils.setup_element_indexer(page)
+
+        for cmd in commands:
+            action = cmd["action"]
+            args = cmd.get("args", [])
+            logger.info(f"Executing: {action} {args}")
+
+            if action == "go_to_url" and args:
+                await page.goto(args[0], wait_until="domcontentloaded")
+                try:
+                    # Use a shorter timeout for networkidle to prevent long hangs
+                    await page.wait_for_load_state("networkidle", timeout=10000)
+                except Exception as e:
+                    logger.warning(f"Network didn't reach idle state, but page is usable: {e}")
+                    # Continue execution even if networkidle isn't reached
+                logger.info(f"Navigated to: {args[0]}")
+            elif action == "wait_for_navigation":
+                await page.wait_for_load_state("networkidle")
+                logger.info("Navigation completed")
+            elif action == "input_text" and len(args) >= 2:
+                selector, value = args[0], args[1]
+                await page.fill(selector, value)
+                logger.info(f"Filled form field '{selector}' with '{value}'")
+            elif action == "click_element" and args:
+                selector = args[0]
+                await page.click(selector)
+                logger.info(f"Clicked element '{selector}'")
+            elif action == "keyboard_press" and args:
+                key = args[0]
+                await page.keyboard.press(key)
+                logger.info(f"Pressed key '{key}'")
+            elif action == "extract_content":
+                selectors = args if args else ["h1", "h2", "h3", "p"]
+                content = {}
+                for selector in selectors:
+                    elements = await page.query_selector_all(selector)
+                    texts = [await element.text_content() for element in elements if (await element.text_content()).strip()]
+                    content[selector] = texts
+                logger.info("\nExtracted content:")
+                logger.info(json.dumps(content, indent=2))
+
+            # Small delay between commands for stability
+            await asyncio.sleep(1)
+
+        # Close only the tab, keeping the browser open
+        await page.close()
+        
+        # Only stop playwright if this was not a CDP connection
+        if not browser_data.get("is_cdp", False):
+            await browser_data["playwright"].stop()
+
+    except Exception as e:
+        logger.error(f"\nError executing commands: {e}")
+        import traceback
+        logger.error(traceback.format_exc())

--- a/src/modules/execution_debug_engine.py
+++ b/src/modules/execution_debug_engine.py
@@ -11,7 +11,7 @@ class ExecutionDebugEngine:
         """実行エンジンの初期化"""
         self.browser_manager = BrowserDebugManager()
     
-    async def execute_commands(self, commands, use_own_browser=False, headless=False, tab_selection="active"):
+    async def execute_commands(self, commands, use_own_browser=False, headless=False, tab_selection="active_tab", action_type=None, keep_tab_open=None):
         """
         Execute a list of commands in the browser.
         
@@ -19,12 +19,20 @@ class ExecutionDebugEngine:
             commands: List of commands to execute.
             use_own_browser: Whether to use the user's own browser.
             headless: Whether to run in headless mode.
-            tab_selection: Strategy for selecting a tab ("new", "active", "last").
+            tab_selection: Strategy for selecting a tab ("new_tab", "active_tab", "last_tab").
+            action_type: Type of action (e.g., "unlock-future").
+            keep_tab_open: Whether to keep the tab open after execution.
         """
         print("\nコマンドを実行しています:")
         for i, cmd in enumerate(commands, 1):
             print(f" {i}. {cmd['action']}: {cmd.get('args', [])}")
 
+        # Default to true for unlock-future type, otherwise default to false
+        if keep_tab_open is None:
+            keep_tab_open = True if action_type == "unlock-future" else False
+        
+        print(f"🔍 DEBUG: Action Type: {action_type}, Keep Tab Open: {keep_tab_open}")
+        
         try:
             print("ブラウザを初期化しています...")
             browser_data = await self.browser_manager.initialize_custom_browser(use_own_browser, headless)
@@ -78,10 +86,16 @@ class ExecutionDebugEngine:
                 print("\nコマンドを実行しました。次のコマンドは3秒後...")
                 await asyncio.sleep(3)
 
-            # Close the tab if it was newly created
-            if is_new:
+            # Handle tab closure based on keep_tab_open setting
+            print("\n✅ Execution complete.")
+            if not keep_tab_open:
+                print("Tab will close in 5 seconds...")
+                print("(Press Ctrl+C to close earlier)")
+                await asyncio.sleep(5)
                 await page.close()
-                print("✅ 新しいタブを閉じました")
+                print("✅ タブを閉じました")
+            else:
+                print("✅ タブを開いたままにします（keep_tab_open: true）")
 
         except Exception as e:
             print(f"\nコマンド実行中にエラーが発生しました: {e}")
@@ -252,12 +266,18 @@ class ExecutionDebugEngine:
             import traceback
             print(traceback.format_exc())
 
-    async def execute_json_commands(self, commands_data, use_own_browser=False, headless=False, action_name=None, params=None):
+    async def execute_json_commands(self, commands_data, use_own_browser=False, headless=False, action_name=None, params=None, tab_selection=None):
         """Execute JSON or YAML commands for browser automation."""
         try:
             # Debug input data type and value
             print(f"🔍 DEBUG [execute_json_commands]: commands_data の型: {type(commands_data)}")
             print(f"🔍 DEBUG [execute_json_commands]: commands_data の値: {commands_data}")
+            
+            # Initial debugging for keep_tab_open
+            print(f"🔍 DEBUG [initial]: keep_tab_open の初期状態: {commands_data.get('keep_tab_open', 'Not Set')}")
+            
+            action_type = None
+            keep_tab_open = None
             
             # Handle file path input
             if isinstance(commands_data, str) and (commands_data.endswith('.txt') or commands_data.endswith('.yml') or commands_data.endswith('.yaml')):
@@ -286,91 +306,57 @@ class ExecutionDebugEngine:
                         # Debug action detection
                         print(f"🔍 DEBUG: 指定されたactionが見つかりました: {action is not None}")
                         if action:
-                            print(f"🔍 DEBUG: Action名: {action.get('name', '無名')}")
-                            print(f"🔍 DEBUG: フローステップ数: {len(action.get('flow', []))}")
-                            print(f"🔍 DEBUG: Action詳細: {json.dumps(action, ensure_ascii=False)}")
-                        
-                        if not action:
-                            print("❌ 指定されたactionがllms.txtに見つかりませんでした")
-                            return
+                            # Extract key information from the found action
+                            action_type = action.get('type')
+                            keep_tab_open = action.get('keep_tab_open', False)  # Default to False if not set
                             
-                        print(f"✅ 使用するaction: {action.get('name', '無名')}")
-                        
-                        # Convert action flow to commands format
-                        commands = []
-                        for i, step in enumerate(action.get('flow', [])):
-                            # Debug current step
-                            print(f"🔍 DEBUG: ステップ {i+1} を処理中: {step}")
-                            
-                            cmd = {"action": step.get('action', '')}
-                            
-                            # Handle different action types
-                            if 'url' in step:
-                                cmd['args'] = [step['url']]
-                                print(f"🔍 DEBUG: URLを追加: {step['url']}")
-                            elif 'selector' in step:
-                                cmd['selector'] = step['selector']
-                                print(f"🔍 DEBUG: セレクタを追加: {step['selector']}")
-                            
-                            # Handle additional parameters
-                            for key, value in step.items():
-                                if key not in ['action', 'url', 'args']:
-                                    # Perform parameter substitution
-                                    if isinstance(value, str) and '${params.' in value:
-                                        param_name = value.split('${params.')[1].split('}')[0]
-                                        if param_name in params:
-                                            value = value.replace(f"${{params.{param_name}}}", params[param_name])
-                                            print(f"🔍 DEBUG: パラメータ置換: {key}の値を{value}に変更")
-                                    cmd[key] = value
-                                    print(f"🔍 DEBUG: パラメータを追加 {key}: {value}")
-                                        
-                            commands.append(cmd)
-                            print(f"🔍 DEBUG: コマンドを追加: {cmd}")
-                        
-                        # Create the commands structure
-                        commands_data = {
-                            "action_type": action.get('type', 'browser-control'),
-                            "commands": commands,
-                            "slowmo": action.get('slowmo', 1000)
-                        }
-                        
-                        # Debug final commands_data structure
-                        print(f"🔍 DEBUG: 最終的なcommands_data構造:")
-                        print(f"🔍 DEBUG: - action_type: {commands_data['action_type']}")
-                        print(f"🔍 DEBUG: - コマンド数: {len(commands_data['commands'])}")
-                        print(f"🔍 DEBUG: - slowmo: {commands_data['slowmo']}")
-                        print(f"🔍 DEBUG: - 全コマンド: {json.dumps(commands_data['commands'], ensure_ascii=False)}")
-                        
-                        if hasattr(result, 'instructions'):
-                            print("🔎 読み込まれた指示の詳細:")
-                            for i, instr in enumerate(result.instructions):
-                                print(f"  指示 {i+1}:")
-                                print(f"  - タイプ: {type(instr)}")
-                                if isinstance(instr, dict):
-                                    print(f"  - キー: {list(instr.keys())}")
-                                    if 'name' in instr:
-                                        print(f"  - 名前: {instr['name']}")
-                                    if 'flow' in instr:
-                                        print(f"  - フローステップ数: {len(instr['flow'])}")
-                    
-                    # For other YAML files, use direct loading
+                            # Convert flow to commands format expected by execution engine
+                            flow = action.get('flow', [])
+                            commands_data = {
+                                'commands': flow,
+                                'action_type': action_type,
+                                'keep_tab_open': keep_tab_open,
+                                'slowmo': action.get('slowmo', 1000)
+                            }
+                            print(f"🔍 DEBUG: アクションから抽出したkeep_tab_open: {keep_tab_open}")
+
                     else:
-                        yaml_data = load_yaml_from_file(commands_data)
-                        if not yaml_data:
-                            print(f"❌ Failed to load or parse YAML from {commands_data}")
-                            return
-                        commands_data = yaml_data
+                        # For other YAML/YML files
+                        commands_data = load_yaml_from_file(commands_data)
                     
                 except Exception as e:
                     print(f"❌ Error processing file {commands_data}: {e}")
                     import traceback
-                    print(traceback.format_exc())
+                    traceback.print_exc()
                     return
             
+            # After processing llms.txt
+            if isinstance(commands_data, dict) and 'keep_tab_open' in commands_data:
+                print(f"🔍 DEBUG [after loading]: commands_data から keep_tab_open: {commands_data['keep_tab_open']}")
+            
             # Extract command information
-            action_type = commands_data.get("action_type", "browser-control")
+            action_type = action_type or commands_data.get("action_type", "unlock-future")
             commands = commands_data.get("commands", [])
             slowmo = commands_data.get("slowmo", 1000)
+            
+            # Get keep_tab_open flag - default to True for unlock-future type
+            if keep_tab_open is None:
+                keep_tab_open = commands_data.get("keep_tab_open", True)
+                print(f"🔍 DEBUG [default]: keep_tab_open の初期値: {keep_tab_open}")
+                if keep_tab_open is None:
+                    keep_tab_open = True 
+                    print(f"🔍 DEBUG [default]: 1.Setting keep_tab_open to True")
+                    if action_type == "unlock-future" and keep_tab_open:
+                        keep_tab_open = True
+                        print(f"🔍 DEBUG [unlock-future]: Setting keep_tab_open to True")
+                    else:
+                        keep_tab_open = True
+                        print(f"🔍 DEBUG [default]: 2.Setting keep_tab_open to True")
+                    
+            print(f"🔍 DEBUG [final decision]: Action Type: {action_type}, Keep Tab Open: {keep_tab_open}")
+            print(f"🔍 DEBUG [commands_data state]: 'keep_tab_open' in commands_data: {'keep_tab_open' in commands_data}")
+            if 'keep_tab_open' in commands_data:
+                print(f"🔍 DEBUG [commands_data state]: commands_data['keep_tab_open'] = {commands_data['keep_tab_open']}")
             
             # Validate commands structure
             if not commands:
@@ -383,15 +369,16 @@ class ExecutionDebugEngine:
             browser_data = await self.browser_manager.initialize_custom_browser(use_own_browser, headless)
             browser = browser_data["browser"]
             
-            # Get or create context
-            if browser_data.get("is_cdp", False):
-                context = browser.contexts[0] if browser.contexts else await browser.new_context()
-                print("✅ Using existing Chrome window with a new tab")
-            else:
-                context = browser_data.get("context") or await browser.new_context()
+            # 引数のtab_selectionを優先し、なければcommands_dataから取得
+            tab_strategy = tab_selection or commands_data.get('tab_selection_strategy', 'new_tab')
+            print(f"🔍 DEBUG [tab_selection_strategy]: Initial tab selection strategy: {tab_strategy}, from arg: {tab_selection}")
             
-            # Create a new page/tab
-            page = await context.new_page()
+            # Use tab selection strategy to get or create a tab
+            context, page, is_new = await self.browser_manager.get_or_create_tab(tab_strategy)
+            print(f"✅ {'新しい' if is_new else '既存の'}タブを使用します (タブ選択戦略: {tab_strategy})")
+            
+            # Highlight the tab being automated
+            await self.browser_manager.highlight_automated_tab(page)
             
             try:
                 # Execute each command
@@ -400,11 +387,11 @@ class ExecutionDebugEngine:
                     
                     # Log the command being executed
                     print(f"Command {i}/{len(commands)}: {action}")
-                    print(f"Details: {json.dumps(cmd, ensure_ascii=False)}")
+                    print(f"Details: {json.dumps(cmd, indent=2, ensure_ascii=False)}")
                     
                     if action == "command":
                         # Handle URL from args or direct url field
-                        url = cmd.get("url") or (cmd.get("args", [""])[0] if "args" in cmd else "")
+                        url = cmd.get("url") or (cmd.get("args", [""])[0] if "args" in cmd and cmd["args"] else "")
                         if not url:
                             print("⚠️ Missing URL in command action, skipping...")
                             continue
@@ -418,7 +405,8 @@ class ExecutionDebugEngine:
                             print(f"✅ Waited for selector: {cmd['wait_for']}")
                     
                     elif action == "click":
-                        selector = cmd.get("selector")
+                        # Get selector from direct property or args array
+                        selector = cmd.get("selector") or (cmd.get("args", [""])[0] if "args" in cmd and cmd["args"] else "")
                         if not selector:
                             print("⚠️ Missing selector for click action, skipping...")
                             continue
@@ -433,28 +421,20 @@ class ExecutionDebugEngine:
                             print("✅ Waited for navigation to complete")
                     
                     elif action == "fill_form":
-                        selector = cmd.get("selector")
-                        value = cmd.get("value")
+                        # Get selector and value from direct properties or args array
+                        selector = cmd.get("selector") or (cmd.get("args", [""])[0] if "args" in cmd and len(cmd.get("args", [])) > 0 else "")
+                        value = cmd.get("value") or (cmd.get("args", ["", ""])[1] if "args" in cmd and len(cmd.get("args", [])) > 1 else None)
                         
                         if not selector or value is None:
                             print("⚠️ Missing selector or value for fill_form action, skipping...")
                             continue
                         
-                        # コマンド生成部分で、valueがある場合に追加
-                        if 'value' in cmd and isinstance(cmd['value'], str) and '${params.' in cmd['value']:
-                            print(f"🔎 パラメータ置換前の値: {cmd['value']}")
-                            # パラメータ置換処理を実装
-                            param_name = cmd['value'].split('${params.')[1].split('}')[0]
-                            if param_name in params:
-                                cmd['value'] = cmd['value'].replace(f"${{params.{param_name}}}", params[param_name])
-                                print(f"🔎 パラメータ置換後の値: {cmd['value']}")
-                        
                         await page.fill(selector, value)
                         print(f"✅ Filled {selector} with: {value}")
                     
                     elif action == "keyboard_press":
-                        # Get key from selector or key property
-                        key = cmd.get("key") or cmd.get("selector")
+                        # Get key from selector, key property, or args array
+                        key = cmd.get("key") or cmd.get("selector") or (cmd.get("args", [""])[0] if "args" in cmd and cmd["args"] else "")
                         
                         if not key:
                             print("⚠️ Missing key for keyboard_press action, skipping...")
@@ -474,19 +454,30 @@ class ExecutionDebugEngine:
                     # Apply slowmo delay between actions
                     await asyncio.sleep(slowmo / 1000)
                 
+                # Just before tab closure decision
+                print(f"🔍 DEBUG [before closure decision]: Final keep_tab_open value: {keep_tab_open}")
+                
                 # Allow time to view the result
-                print("\n✅ Execution complete. Tab will close in 30 seconds...")
-                print("(Press Ctrl+C to close earlier)")
-                await asyncio.sleep(30)
+                print("\n✅ Execution complete.")
+                if not keep_tab_open:
+                    print("Tab will close in 5 seconds...")
+                    print("(Press Ctrl+C to close earlier)")
+                    await asyncio.sleep(5)
+                else:
+                    print("Tab will remain open as requested.")
                 
             except Exception as e:
                 print(f"❌ Error during command execution: {e}")
                 import traceback
-                print(traceback.format_exc())
+                traceback.print_exc()
                 
             finally:
-                # Keep tab open as requested
-                print("タブ開けっぱなし")
+                # Close tab based on keep_tab_open setting
+                if not keep_tab_open:
+                    await page.close()
+                    print("✅ タブを閉じました")
+                else:
+                    print("✅ タブを開いたままにしました（keep_tab_open: true）")
         
         except Exception as e:
             print(f"❌ Error in execute_json_commands: {e}")

--- a/src/script/script_manager.py
+++ b/src/script/script_manager.py
@@ -328,7 +328,8 @@ markers =
                 json_path = translator.translate_to_json(
                     script_info.get('name', ''), 
                     params, 
-                    action_list
+                    action_list,
+                    tab_selection_strategy=script_info.get('tab_selection_strategy', 'new_tab')  # Pass tab selection strategy
                 )
                 
                 # Execute the JSON commands using DebugUtils

--- a/src/ui/stream_manager.py
+++ b/src/ui/stream_manager.py
@@ -37,7 +37,7 @@ async def run_with_stream(
     tool_calling_method: str,
     dev_mode: bool = False,
     maintain_browser_session: bool = False,  # Added parameter
-    tab_selection_strategy: str = "new_tab"  # Add parameter with default
+    tab_selection_strategy: str = "active_tab"  # Add parameter with default
 ):
     """
     Run browser agent with UI streaming of results


### PR DESCRIPTION
- Enhanced BrowserDebugManager's get_or_create_tab method to fully support active_tab, new_tab, and last_tab strategies
- Added explicit tab_selection_strategy configuration in action definitions (e.g., active_tab for click-jsonpayload, new_tab for nogtips-jsonpayload)
- Updated ExecutionDebugEngine to prioritize explicitly provided tab_selection arguments over commands_data values
- Implemented more robust CDP-based active tab detection with improved fallback mechanisms
- Added UI controls for tab selection strategy with conditional visibility based on use_own_browser setting
- Set "active_tab" as the default strategy in the UI for better user experience
- Fixed keep_tab_open functionality to properly maintain browser state between operations
- Ensured tab selection strategy is properly propagated through the execution pipeline
- Improved error handling for tab management operations with more descriptive user feedback