### PR TITLE
Wave A3 Issue #30 動画アーティファクト登録/正規化 基盤実装

### DIFF
--- a/config/feature_flags.yaml
+++ b/config/feature_flags.yaml
@@ -23,3 +23,11 @@ flags:
     description: "動画アーティファクト保持期間(日) (#37) 0=無効"
     type: int
     default: 7
+  artifacts.video_target_container:
+    description: "録画動画ターゲットコンテナ (#30) 'auto' or 'mp4'"
+    type: str
+    default: auto
+  artifacts.video_transcode_enabled:
+    description: "webm→mp4 変換を有効化 (ffmpeg 必須, #30)"
+    type: bool
+    default: false

--- a/src/agent/agent_manager.py
+++ b/src/agent/agent_manager.py
@@ -2,6 +2,7 @@ import os
 import logging
 import traceback
 import glob
+from pathlib import Path
 from typing import Tuple, Optional, Dict, Any
 
 import gradio as gr
@@ -42,6 +43,7 @@ else:
 from src.utils.utils import get_latest_files
 from src.script.script_manager import run_script
 from src.browser.browser_manager import prepare_recording_path
+from src.core.artifact_manager import get_artifact_manager
 from src.utils import utils
 from src.utils.globals_manager import get_globals, _global_browser, _global_browser_context, _global_agent, _global_agent_state
 
@@ -486,6 +488,11 @@ async def run_browser_agent(
                            glob.glob(os.path.join(recording_path, "*.[wW][eE][bB][mM]")))
             if new_videos - existing_videos:
                 latest_video = list(new_videos - existing_videos)[0]
+                # Register artifact (Issue #30 integration)
+                try:
+                    get_artifact_manager().register_video_file(Path(latest_video))
+                except Exception:
+                    pass
 
         return (
             final_result, errors, model_actions, model_thoughts, latest_video, trace_file, history_file,

--- a/tests/test_video_artifact_registration.py
+++ b/tests/test_video_artifact_registration.py
@@ -1,0 +1,30 @@
+import os
+from pathlib import Path
+from src.core.artifact_manager import get_artifact_manager
+from src.config.feature_flags import FeatureFlags
+
+
+def test_register_video_artifact(tmp_path, monkeypatch):
+    # Enable manifest v2
+    FeatureFlags.set_override("artifacts.enable_manifest_v2", True)
+    manager = get_artifact_manager()
+    video_dir = manager.dir / "videos"
+    video_dir.mkdir(parents=True, exist_ok=True)
+    sample_video = video_dir / "sample.webm"
+    sample_video.write_bytes(b"RIFFXXXXwebmfake")
+
+    # Force target container auto (no transcode)
+    FeatureFlags.set_override("artifacts.video_target_container", "auto")
+    out = manager.register_video_file(sample_video)
+    assert out.exists()
+
+    manifest = (manager.dir / "manifest_v2.json")
+    assert manifest.exists()
+    data = manifest.read_text(encoding="utf-8")
+    assert "sample.webm" in data
+
+    # Switch to mp4 target (transcode disabled so original kept)
+    FeatureFlags.set_override("artifacts.video_target_container", "mp4")
+    FeatureFlags.set_override("artifacts.video_transcode_enabled", False)
+    out2 = manager.register_video_file(sample_video)
+    assert out2.suffix.lower() == ".webm"  # no change without transcode

--- a/tests/test_video_metrics.py
+++ b/tests/test_video_metrics.py
@@ -1,0 +1,17 @@
+from pathlib import Path
+from src.core.artifact_manager import get_artifact_manager
+from src.config.feature_flags import FeatureFlags
+
+def test_video_metrics_increment(tmp_path, monkeypatch):
+    FeatureFlags.set_override("artifacts.enable_manifest_v2", True)
+    FeatureFlags.set_override("artifacts.video_target_container", "auto")
+    manager = get_artifact_manager()
+    video_dir = manager.dir / "videos"
+    video_dir.mkdir(parents=True, exist_ok=True)
+    v1 = video_dir / "m1.webm"
+    v1.write_bytes(b"RIFFXXXXwebmfake1")
+    manager.register_video_file(v1)
+    metrics = manager.get_video_metrics()
+    assert metrics["videos_total"] >= 1
+    assert metrics["videos_transcoded"] >= 0
+    assert metrics["video_bytes_total"] >= len(b"RIFFXXXXwebmfake1")


### PR DESCRIPTION
# PR: Wave A3 Issue #30 動画アーティファクト登録/正規化 基盤実装

## 対象 Issue
- Close: #30 (動画アーティファクト基本登録 & 変換フラグ基盤)
- 関連: #28, #33, #35, #36, #37, #58 (後続最適化/拡張ポイント列挙)

## 変更概要
1. ArtifactManager
    - register_video_file 実装: 動画登録 + (フラグ駆動) コンテナ変換
    - ffmpeg 検出 (PATH) / 失敗時フォールバック安全化
    - 変換メタ情報 (original_ext, final_ext, transcoded, duration_ms) を Manifest v2 に格納
    - POSIX 相対パス格納で Windows/非POSIX 互換性改善
    - プロセス内メトリクス: 動画総数 / 変換数 / 総バイト数
    - get_video_metrics 追加
2. Feature Flags 追加
    - artifacts.video_target_container (default: auto)
    - artifacts.video_transcode_enabled (default: false)
3. テスト
    - test_video_artifact_registration.py: 既存動画登録正常系
    - test_video_metrics.py: メトリクスインクリメント最小検証
4. 回帰防止
    - 既存デフォルト挙動: 変換無効 (ffmpeg未要求) で従来 .webm をそのまま利用可能
5. Manifest v2: 動画エントリ書式確立 (後続 #35 で正式化予定)

## スコープ外 (意図的未対応 / 別Issue推奨)

|項目|理由|推奨Issue|
|----------------------------|------|------|
|ffmpeg 実変換 E2E テスト|CI安定性/環境差異|新: “Video transcode CI test”|
|動画メタ(解像度/秒数) 解析|解析コスト (#58と併合)|#58|
|全録画経路の呼び出し統一|#28/#33 と同時が差分最小|#28/#33|
|Retention 実行タイミング|#37 実装時統合|#37|
|/api/artifacts メトリクス返却|API肥大回避|#36 拡張|
|Manifest v2 スキーマDoc/テスト|#35 クローズ条件|#35|

## 設計メモ
- 変換は「安全な最適化」: フラグ無効時は一切副作用無し
- 変換条件: (transcode_enabled && target_container!=auto && 拡張子差異 && ffmpeg存在)
- 競合防止: 単純ロックでメトリクス加算
- 書き込み: manifest は都度完全再書き込み (小規模 JSON 前提)

## リスクと軽減策
|リスク|軽減|
|---|---|
|ffmpeg 不在/失敗|例外捕捉 + 元ファイル登録|
|変換失敗によるテスト不安定|デフォルト無効|
|パス不整合 (Win)|相対 POSIX 正規化|
|将来メトリクス導入との二重実装|後続 #58 で統合予定|


## テスト実行ログ (要約)
- 実行: 仮想環境 venv 利用
- 対象: 新規 2 テスト
- 結果: 2 passed (警告: pytest unknown config 1件 / 既存設定由来)
- カバレッジ: 目的コード (ArtifactManager 動画周り) は実行確認済み

## 手動検証シナリオ (簡易)
- フラグ auto / transcode=false で .webm 登録 -> manifest に video entry
- artifacts.video_target_container=mp4 + transcode=false -> 拡張子維持
- video_transcode_enabled=true + ffmpeg 有り環境 -> .mp4 出力想定 (次段E2E)

## 互換性
- 既存 tmp/record_videos パスは flag off 時保持
- Manifest v1 呼び出し箇所には未干渉 (v2 導入を段階的に安全化)

## 追跡すべきフォローアップ
- 上記スコープ外テーブルに列挙
- 特に (#28/#33) 実装時に録画開始/終了フックへ ArtifactManager.register_video_file 統一呼び出し再確認

## ログイベント一覧 (プレフィックス artifact.video.*)
- register.start / register.complete / register.error
- transcode.start / transcode.success / transcode.fail
- manifest.fail

## PR チェックリスト
    - [x] Feature flags 追加
    - [x] 動画登録 & メタ格納
    - [x] 変換ロジック (失敗安全)
    - [x] メトリクス集計
    - [x] テスト追加 & 実行
    - [x] 既存挙動互換性検証（デフォルト無変換）
    - [x] フォローアップ項目列挙

## Close Policy
- 本PRで #30 の「動画登録基盤 & 変換フラグ導入」要件は満たす
- 上記追加最適化を別Issue化する場合: #30 を Close、フォローアップ起票 あるいは #30 を Open 維持しスコープ再定義 (チーム判断) 推奨: Close #30 + 新Issue分割 (履歴明確化)