### PR TITLE
feat(artifacts): Issue #87 重複スクリーンショット保存フラグ & duplicate_copy ログ

### DIFF
--- a/docs/artifacts/ARTIFACTS_MANIFEST.md
+++ b/docs/artifacts/ARTIFACTS_MANIFEST.md
@@ -12,6 +12,7 @@ Wave A3 の範囲では video / screenshot / element_capture の 3 種を対象�
 |------|----------------------|---------|------|
 | video | videos/*.mp4(webm) | original_ext / final_ext / transcoded / register_duration_ms | 変換は ffmpeg 存在時 (#30) |
 | screenshot | screenshots/*.png | format: png | 将来 user_named (#87) 追加予定 |
+| screenshot (duplicate copy) | screenshots/`<prefix>`_`<ts>`.png | format: png | Flag `artifacts.screenshot.user_named_copy_enabled` (Issue #87) により生成 / OFF で無効 |
 | element_capture | elements/*.json | selector: \<CSS\> | JSON 本体に text/value/captured_at |
 
 ## JSON 構造 (最小)

--- a/docs/artifacts/ARTIFACTS_MANIFEST.md
+++ b/docs/artifacts/ARTIFACTS_MANIFEST.md
@@ -107,3 +107,4 @@ Wave A3 の範囲では video / screenshot / element_capture の 3 種を対象�
 | 2.0.0 | 2025-08-26 | 初期包括ドラフト | Copilot Agent |
 | 2.0.1 | 2025-09-03 | Issue #35 最小スキーマ定義へスコープ縮小 / 過剰フィールド分離 | Copilot Agent |
 | 2.0.2 | 2025-09-03 | Issue #36 一覧 API 仕様/レスポンス記述 & 将来拡張 TODO 追加 (links: #37 #58 #38 #87 #88 #89) | Copilot Agent |
+| 2.0.3 | 2025-09-03 | Issue #87 重複ユーザー向けスクリーンショットコピー行追加 / Flag 説明明記 | Copilot Agent |

--- a/src/core/screenshot_manager.py
+++ b/src/core/screenshot_manager.py
@@ -50,15 +50,19 @@ def capture_page_screenshot(page, prefix: str = _DEF_PREFIX, image_format: str =
             write_dup = FeatureFlags.is_enabled("artifacts.screenshot.user_named_copy_enabled")  # type: ignore
         except Exception:
             write_dup = True
+        duplicate_copy = False
         if write_dup:
             user_named = path.parent / fname
             if not user_named.exists():
                 try:
                     user_named.write_bytes(raw_bytes)
+                    duplicate_copy = True
                 except Exception as dup_exc:  # noqa: BLE001
                     logger.warning(f"[screenshot_manager] duplicate_copy_fail target={user_named} error={dup_exc}")
         b64 = base64.b64encode(raw_bytes).decode("utf-8")
-        logger.info(f"[screenshot_manager] capture_success prefix={prefix} path={path}")
+        logger.info(
+            f"[screenshot_manager] capture_success prefix={prefix} path={path} duplicate_copy={duplicate_copy}"
+        )
         return path, b64
     except Exception as exc:  # noqa: BLE001
         logger.error(f"[screenshot_manager] persist_fail prefix={prefix} error={exc}")

--- a/src/core/screenshot_manager.py
+++ b/src/core/screenshot_manager.py
@@ -56,9 +56,11 @@ def capture_page_screenshot(page, prefix: str = _DEF_PREFIX, image_format: str =
             if not user_named.exists():
                 try:
                     user_named.write_bytes(raw_bytes)
-                    duplicate_copy = True
                 except Exception as dup_exc:  # noqa: BLE001
+                    # Failure to create the optional duplicate should not fail overall capture.
                     logger.warning(f"[screenshot_manager] duplicate_copy_fail target={user_named} error={dup_exc}")
+            # PR #96 review: treat duplicate_copy as "present after operation" (either pre-existing or just written)
+            duplicate_copy = user_named.exists()
         b64 = base64.b64encode(raw_bytes).decode("utf-8")
         logger.info(
             f"[screenshot_manager] capture_success prefix={prefix} path={path} duplicate_copy={duplicate_copy}"

--- a/tests/test_screenshot_duplicate_flag.py
+++ b/tests/test_screenshot_duplicate_flag.py
@@ -1,0 +1,47 @@
+import os
+from pathlib import Path
+
+import pytest
+
+from src.config.feature_flags import FeatureFlags
+from src.runtime.run_context import RunContext
+from src.core.screenshot_manager import capture_page_screenshot
+from src.core.artifact_manager import reset_artifact_manager_singleton
+
+
+class DummyPage:
+    def __init__(self, content: bytes = b"imgdata"):
+        self._content = content
+    def screenshot(self, type: str = "png"):
+        return self._content
+
+
+@pytest.mark.ci_safe
+def test_screenshot_duplicate_flag_on(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("BYKILT_RUN_ID", "SCRDUPON")
+    RunContext.reset(); reset_artifact_manager_singleton(); FeatureFlags.reload()
+    # ensure flag on
+    FeatureFlags.set_override("artifacts.screenshot.user_named_copy_enabled", True)
+
+    page = DummyPage()
+    path, _ = capture_page_screenshot(page, prefix="sample")
+    assert path is not None
+    pdir = path.parent
+    # duplicate user-named file should exist (prefix_<timestamp>.png) -> we derive by glob
+    dup_files = [p for p in pdir.glob("sample_*.png") if p.name != path.name]
+    assert len(dup_files) == 1
+
+@pytest.mark.ci_safe
+def test_screenshot_duplicate_flag_off(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("BYKILT_RUN_ID", "SCRDUPOFF")
+    RunContext.reset(); reset_artifact_manager_singleton(); FeatureFlags.reload()
+    FeatureFlags.set_override("artifacts.screenshot.user_named_copy_enabled", False)
+
+    page = DummyPage()
+    path, _ = capture_page_screenshot(page, prefix="only")
+    assert path is not None
+    pdir = path.parent
+    dup_files = [p for p in pdir.glob("only_*.png") if p.name != path.name]
+    assert len(dup_files) == 0


### PR DESCRIPTION
## 概要 (Issue #87 スクリーンショット重複保存フラグ導入)

`artifacts.screenshot.user_named_copy_enabled` フラグで、既存のユーザー向け安定ファイル名 (prefix + timestamp) による重複コピー生成を制御可能にし、ログへ `duplicate_copy=<bool>` を追加。I/O 削減や将来の manifest 参照一本化に向けた移行ステップ。

## 対象 Issue
- Closes #87

## 背景
Manifest v2 (#35) 導入後も従来パス (`screenshots/<prefix>_<ts>.png`) を期待する利用形態が存在。将来的に単一書き込みへ簡潔化するため、後方互換を保持しつつ挙動をフラグ化。

## 目的
1. 重複書き込みの明示的制御 (I/O 削減余地)
2. ログで生成有無を即判別
3. 将来フラグ OFF デフォルト化→撤去判断を容易化

## 変更概要
- コード: `capture_page_screenshot` 内で duplicate copy 有無を判定し `duplicate_copy` ログ出力
- フラグ利用: `FeatureFlags.is_enabled("artifacts.screenshot.user_named_copy_enabled")`
- テスト: フラグ ON/OFF で重複ファイル存在差異を検証
- ドキュメント: `ARTIFACTS_MANIFEST.md` に “screenshot (duplicate copy)” 行と改訂履歴 2.0.3 追加
- ログ: 成功行 `[screenshot_manager] capture_success ... duplicate_copy=<bool>`

## 詳細変更
| 種別 | パス | 要約 |
|------|------|------|
| feat | `src/core/screenshot_manager.py` | duplicate_copy 判定・書き込み・ログ追加 |
| test | `tests/test_screenshot_duplicate_flag.py` | ON/OFF 2 ケース (ci_safe) |
| docs | `docs/artifacts/ARTIFACTS_MANIFEST.md` | 行追加 + 改訂履歴 2.0.3 |

## ログ例
```
[screenshot_manager] capture_success prefix=sample path=.../screenshots/sample_20250903_123456.png duplicate_copy=True
```

## フラグ
| 名前 | デフォルト | 効果 | 無効化時 |
|------|------------|------|----------|
| artifacts.screenshot.user_named_copy_enabled | true | 重複ユーザー向け命名ファイル作成 | 単一 (ArtifactManager 管理名のみ) |

## Acceptance Criteria 対応表
| 条件 | 実装状況 |
|------|----------|
| フラグで重複コピー生成を制御 | OK |
| ログに duplicate_copy 出力 | OK |
| OFF で重複ファイル未生成 | OK (テスト) |
| ON で重複生成 | OK (テスト) |
| ドキュメント更新 | OK |
| 既存挙動 (デフォルト true) 維持 | OK |

## テスト
- `tests/test_screenshot_duplicate_flag.py`:
  - ON: `glob("prefix_*.png")` に基準ファイル以外 1 件
  - OFF: 0 件
- ci_safe マーカーで軽量
- 既存他領域へ影響なし (副作用限定)

## リスク & 緩和
| リスク | 緩和 |
|--------|------|
| Flag 誤設定による期待ファイル不在 | ログ duplicate_copy=false で検知 |
| 書き込み失敗 | WARN ログ & 主ファイル保持 |
| 将来削除判断遅延 | Manifest v2 利用率計測 (#58) で撤去基準化 |

## フォローアップ
- #88: 例外分類 (broad except 解消)
- #89: metrics 連携用構造化ログ (duration / size)
- Flag デフォルト将来 false 化検討 (manifest UI 安定後)

## 破壊的変更
なし (デフォルト挙動維持)

## マイグレーション指針 (任意)
重複ファイル非依存コードは早期に manifest v2 (`artifacts/runs/.../manifest_v2.json`) への参照へ移行推奨。

## チェックリスト
- [x] コード実装
- [x] テスト追加 & パス
- [x] ドキュメント更新
- [x] ログ項目確認
- [x] フラグ参照 (既存定義) 動作
- [ ] ISSUE_DEPENDENCIES.yml 更新 (マージ後)
- [ ] PR レビュー反映

