### PR TITLE
feat: Complete Phase2-06 artifacts stabilization (#106, #104)

### DIFF
--- a/docs/artifacts/RECORDING_PATH_MIGRATION.md
+++ b/docs/artifacts/RECORDING_PATH_MIGRATION.md
@@ -46,17 +46,20 @@ artifacts/
 
 ## One-Time Warning
 
-When the flag is disabled:
+When the flag is explicitly disabled (via runtime override or environment variable):
 
 ```text
-Legacy recording path in use; enable artifacts.unified_recording_path (now default true) to migrate
+Legacy recording path explicitly forced; consider enabling artifacts.unified_recording_path
 ```
 
-Logged with event key: `artifact.recording.legacy_path`.
+Logged with event key: `artifact.recording.legacy_path.forced`.
+
+**Note**: As of Issue #106 (Phase 2 enforcement), warnings are only emitted when the flag is explicitly overridden to `false`. Default behavior (flag = `true`) produces no warnings.
 
 ## Test Coverage
 
 - `tests/test_unified_recording_path_rollout.py` validates default path and legacy warning behavior.
+- `tests/artifacts/test_recording_dir_override_warning.py` validates override source detection and conditional warnings (Issue #106).
 - Full suite (174 passed, 1 skipped, 1 xfailed on 2025-09-04) confirms no regressions post-migration.
 
 ## Future Enhancements
@@ -68,3 +71,4 @@ Logged with event key: `artifact.recording.legacy_path`.
 ## Changelog Entry
 
 Added in roadmap revision 1.0.13 (#91 complete).
+Updated in roadmap revision 1.0.26 (#106 Phase 2 enforcement complete).

--- a/docs/roadmap/ROADMAP.md
+++ b/docs/roadmap/ROADMAP.md
@@ -43,12 +43,12 @@
 
 | Wave | Issues | Status | 備考 |
 |------|--------|--------|------|
-| A1 | #64 #65 #63 | ✅ Done | Feature Flags / Multi-env Loader / llms.txt Validator 実装完了 (PR #20 由来) |
+| A1 | #64 ✅ #65 ✅ #63 ✅ | ✅ Done | Feature Flags / Multi-env Loader / llms.txt Validator 実装完了 (PR #20 由来) |
 | A2 | #32 ✅ #31 ✅ #56 ✅ #57 ✅ | ✅ Done | #56 / #57 実装完了 (PR #83) |
 | A3 | #28 ✅ #30 ✅ #33 ✅ #35 ✅ #36 ✅ #34 ✅ #37 ✅ #38 ✅ #87 ✅ #88 ✅ #89 ✅ #91 ✅ | ✅ Done | 全 A3 アーティファクト系 Issue 完了 (#38 PR #103 反映) / Hardening follow-up (非機能) は別 Issue 検討 |
 | A4 | #25 ✅ #44 ✅ #45 ✅ #50 ✅ (#55) | ✅ Done | Runner Reliability / git_script 系統 完了 (PR #118, #120) |
 | A5 | #60 ✅ #61 ✅ | ✅ Done | Security Base (Mask / Scan) (PR #123 マージ完了) |
-| A6 | #58 #59 | ✅ Done | Metrics 基盤 & Run API (Issue #155 として実装完了) |
+| A6 | #58 #59 ✅ | ✅ Done | Metrics 基盤 & Run API (Issue #155 ✅ として実装完了) |
 | A7 | #43 | ✅ Done | LLM Toggle パリティ (PR #157 マージ完了) |
 | Docs | #66 → #67 | In Progress | Doc Sync >90% 維持方針 |
 | A8 | 後続の新規作成issue | Planned | 追加Issueの評価とスケジュール反映 |
@@ -62,15 +62,15 @@ Progress Summary (Phase2): Phase2-04 Done / Phase2-05 Done / Phase2-06 Done / Ph
 
 | Wave (Phase2-XX) | Focus | Issues (順序) | 状態 | 備考 |
 |------------------|-------|---------------|------|------|
-| Phase2-01 | Runner 安定化基盤 | #46 → #47 → #48 | Planned | タイムアウト→並列→環境変数診断 |
+| Phase2-01 | Runner 安定化基盤 | #46 ✅ → #47 ✅ → #48 | Planned | タイムアウト→並列→環境変数診断 |
 | Phase2-02 | Sandbox 強化 & Exec 安全性 | #62 (PoC→Enforce) → #52 | Planned | システムコール/パス制限 → allow/deny 実装 |
 | Phase2-03 | Runner 拡張 (CDP/Windows) | #53 → #54 → #51 | Planned | 調査→抽象レイヤ→Win プロファイル |
 | Phase2-04 | Batch 価値強化 (完了) | #39 ✅ → #41 ✅ → #42 ✅ → #40 ✅ | Done | CSV コア→進捗→部分リトライ→UI |
 | Phase2-05 | Batch 成果物/エクスポート | #175 ✅ → #176 ✅ | Done | ポリシー成果物 & 宣言的抽出 PoC |
-| Phase2-06 | Artifacts 安定化 / 統合 | #111 → #110 → #106 → #104 | ✅ DONE | 録画/パス統合 & flag enforcement |
-| Phase2-07 | Observability 完全化 | #58 ✅ → #59 → #102 | In Progress | Metrics API / Flag artifacts helper |
+| Phase2-06 | Artifacts 安定化 / 統合 | #111 ✅ → #110 ✅ → #106 → #104 | In Progress | 録画/パス統合 & flag enforcement |
+| Phase2-07 | Observability 完全化 | #58 ✅ → #59 ✅ → #102 | In Progress | Metrics API / Flag artifacts helper |
 | Phase2-08 | Quality / Coverage Gate | #109 → #107 → #108 | OPEN | カバレッジ→警告除去→Edge安定化 |
-| Phase2-09 | Security / Compliance | #154 ✅ (follow-ups TBD) | Partial | 追加セキュリティギャップ分析 (#177 連携) |
+| Phase2-09 | Security / Compliance | #154 ✅ (follow-ups TBD) | Partial | 追加セキュリティギャップ分析 (#177 ✅ 連携) |
 | Phase2-10 | Plugin 基盤 | #49 (part1 / part2) | Planned | 増分2段階 (Loader → Lifecycle) |
 | Phase2-11 | Docs & Automation | #66 → #67 → #92 → #81 → #178 ✅ | Done | 整備 / enrichment / workflow 追加 (dependency-pipeline workflow実装完了) |
 | Phase2-12 | MVP 定義 & ギャップ | #177 | ✅ Done | Enterprise readiness matrix 実装完了 (docs/mvp/README.md) |
@@ -156,21 +156,21 @@ Phase2 再編後の短期優先セットを以下に再定義。A フェーズ�
 ### 優先順位付け方針
 
 - **基盤機能完了**: Group A (A1-A4) の全Waveが完了したため、新機能開発を優先
-- **ユーザーインパクト重視**: #39 (CSV駆動バッチエンジン) はユーザー体験向上効果が高いため優先
-- **セキュリティ重視**: #60 (シークレットマスキング拡張) はセキュリティ強化のため優先
+- **ユーザーインパクト重視**: #39 ✅ (CSV駆動バッチエンジン) はユーザー体験向上効果が高いため優先
+- **セキュリティ重視**: #60 ✅ (シークレットマスキング拡張) はセキュリティ強化のため優先
 
 ### 短期 (Phase2 Kick Re-aligned)
 
-1. Phase2-01 着手: #46 実行タイムアウト → 成功後 #47 concurrency queue draft
-2. Phase2-07 前倒し: #59 Run Metrics API → #102 Flags artifacts helper
+1. Phase2-01 着手: #46 ✅ 実行タイムアウト → 成功後 #47 ✅ concurrency queue draft
+2. Phase2-07 前倒し: #59 ✅ Run Metrics API → #102 ✅ Flags artifacts helper
 3. Phase2-06 開始: #111 録画/パス統合 → #110 browser-control gap fix
-4. Docs ギャップ定義: #177 MVP Matrix Draft → ギャップ派生 Issue 起票
-5. ✅ Workflow 整合性: #178 dependency-pipeline workflow 実装完了 (自動生成・コミット機能統合)
+4. Docs ギャップ定義: #177 ✅ MVP Matrix Draft → ギャップ派生 Issue 起票
+5. Workflow 整合性: #178 ✅ dependency-pipeline workflow 実装完了 (自動生成・コミット機能統合)
 
 ### 中期 (Phase2 Expansion)
 
 1. Sandbox Enforcement Path: #62 PoC → enforce gate → #52 allow/deny materialization
-2. Runner Concurrency & Diagnostics: #47 queue infra → #48 env validation diagnostics
+2. Runner Concurrency & Diagnostics: #47 ✅ queue infra → #48 env validation diagnostics
 3. Plugin Increment (part1): #49 loader + registration minimal
 4. Artifact Stabilization: #111 resolver merge → #110 browser-control gap fix → #106 flag enforcement warn
 
@@ -191,8 +191,8 @@ Phase2 再編後の短期優先セットを以下に再定義。A フェーズ�
 
 ### リスク管理
 
-- **新機能リスク**: #39 は experimental だが、Phase 2 先頭として慎重に実装
-- **セキュリティ優先**: #60 を A5 と並行して早期完了
+- **新機能リスク**: #39 ✅ は experimental だが、Phase 2 先頭として慎重に実装
+- **セキュリティ優先**: #60 ✅ を A5 と並行して早期完了
 - **後方互換**: Flag ベースの段階的導入を徹底
 
 ### 開発フロー (Mermaid - Phase2 色付け試案)
@@ -258,8 +258,9 @@ graph LR
 | 1.0.19 | 2025-09-10 | Group B B4 #39 完了反映 / Phase 2 進捗更新 / Batch Processing 展開準備 | Copilot Agent |
 | 1.0.20 | 2025-09-10 | Wave A8 抽象化 / 次アクションにMermaid/Gitツリー追加 / Wave A完了区切り | Copilot Agent |
 | 1.0.21 | 2025-09-10 | Group C追加 / 未記載OPEN IssueをPhase 3として整理 | Copilot Agent |
-| 1.0.24 | 2025-01-XX | Phase2-07 status updated to In Progress based on ISSUE_DEPENDENCIES.yml latest state | Copilot Agent |
+| 1.0.24 | 2025-09-13 | Phase2-07 status updated to In Progress based on ISSUE_DEPENDENCIES.yml latest state | Copilot Agent |
 | 1.0.25 | 2025-09-14 | Phase2-11 #178 dependency-pipeline workflow 実装完了 / CIジョブ構成更新 / ワークフロー統合反映 | Copilot Agent |
+| 1.0.26 | 2025-09-14 | Phase2 status info update | Nobukins |
 
 ---
 

--- a/tests/artifacts/test_recording_dir_override_warning.py
+++ b/tests/artifacts/test_recording_dir_override_warning.py
@@ -11,6 +11,25 @@ from src.config.feature_flags import FeatureFlags
 from src.runtime.run_context import RunContext
 
 
+"""Tests for ArtifactManager.resolve_recording_dir with override source detection (Issue #106)."""
+import os
+import logging
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from src.core.artifact_manager import ArtifactManager, reset_artifact_manager_singleton
+from src.config.feature_flags import FeatureFlags
+from src.runtime.run_context import RunContext
+
+
+def _clear_legacy_warning_flag():
+    """Helper function to clear the legacy recording warning flag."""
+    if hasattr(ArtifactManager, '_bykilt_legacy_recording_warned'):
+        delattr(ArtifactManager, '_bykilt_legacy_recording_warned')
+
+
 @pytest.fixture
 def setup_test():
     """Reset all state before each test."""
@@ -19,12 +38,10 @@ def setup_test():
     FeatureFlags.clear_all_overrides()
     FeatureFlags.reload()
     # Clear any previous warning flag
-    if hasattr(ArtifactManager, '_bykilt_legacy_recording_warned'):
-        delattr(ArtifactManager, '_bykilt_legacy_recording_warned')
+    _clear_legacy_warning_flag()
     yield
     # Cleanup after test
-    if hasattr(ArtifactManager, '_bykilt_legacy_recording_warned'):
-        delattr(ArtifactManager, '_bykilt_legacy_recording_warned')
+    _clear_legacy_warning_flag()
 
 
 def test_resolve_recording_dir_explicit_path(setup_test):

--- a/tests/artifacts/test_recording_dir_override_warning.py
+++ b/tests/artifacts/test_recording_dir_override_warning.py
@@ -1,0 +1,107 @@
+"""Tests for ArtifactManager.resolve_recording_dir with override source detection (Issue #106)."""
+import os
+import logging
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from src.core.artifact_manager import ArtifactManager, reset_artifact_manager_singleton
+from src.config.feature_flags import FeatureFlags
+from src.runtime.run_context import RunContext
+
+
+@pytest.fixture
+def setup_test():
+    """Reset all state before each test."""
+    RunContext.reset()
+    reset_artifact_manager_singleton()
+    FeatureFlags.clear_all_overrides()
+    FeatureFlags.reload()
+    # Clear any previous warning flag
+    if hasattr(ArtifactManager, '_bykilt_legacy_recording_warned'):
+        delattr(ArtifactManager, '_bykilt_legacy_recording_warned')
+    yield
+    # Cleanup after test
+    if hasattr(ArtifactManager, '_bykilt_legacy_recording_warned'):
+        delattr(ArtifactManager, '_bykilt_legacy_recording_warned')
+
+
+def test_resolve_recording_dir_explicit_path(setup_test):
+    """Test explicit path takes precedence."""
+    explicit = "/tmp/custom/recordings"
+    result = ArtifactManager.resolve_recording_dir(explicit)
+    # On macOS, /tmp is a symlink to /private/tmp, so resolve() normalizes it
+    expected = Path(explicit).resolve()
+    assert result == expected
+
+
+def test_resolve_recording_dir_flag_enabled(setup_test):
+    """Test unified path when flag is enabled (default)."""
+    with patch('src.runtime.run_context.RunContext.get') as mock_rc:
+        mock_artifact_dir = Path("/tmp/test-artifacts/runs/test-art")
+        mock_rc.return_value.artifact_dir.return_value = mock_artifact_dir
+        
+        with patch('pathlib.Path.mkdir'):  # Mock mkdir to avoid filesystem issues
+            result = ArtifactManager.resolve_recording_dir()
+            expected = mock_artifact_dir / "videos"
+            assert result == expected
+
+
+def test_resolve_recording_dir_legacy_no_override(setup_test, caplog):
+    """Test legacy path when flag is false but not explicitly overridden."""
+    # Set flag to false via file default (not override)
+    with patch.object(FeatureFlags, 'is_enabled', return_value=False):
+        with patch.object(FeatureFlags, 'get_override_source', return_value=None):
+            with caplog.at_level(logging.WARNING):
+                result = ArtifactManager.resolve_recording_dir()
+                assert "record_videos" in str(result)
+                # Should not log warning when not explicitly overridden
+                assert len(caplog.records) == 0
+
+
+def test_resolve_recording_dir_legacy_runtime_override(setup_test, caplog):
+    """Test legacy path with runtime override triggers warning."""
+    FeatureFlags.set_override("artifacts.unified_recording_path", False)
+    
+    with caplog.at_level(logging.WARNING):
+        result = ArtifactManager.resolve_recording_dir()
+        assert "record_videos" in str(result)
+        
+        # Should log warning for explicit runtime override
+        assert len(caplog.records) == 1
+        record = caplog.records[0]
+        assert record.levelname == "WARNING"
+        assert "artifact.recording.legacy_path.forced" in record.__dict__.get('event', '')
+        assert "runtime" in str(record.__dict__.get('override_source', ''))
+
+
+def test_resolve_recording_dir_legacy_env_override(setup_test, caplog, monkeypatch):
+    """Test legacy path with environment override triggers warning."""
+    monkeypatch.setenv("BYKILT_FLAG_ARTIFACTS_UNIFIED_RECORDING_PATH", "false")
+    FeatureFlags.reload()
+    
+    with caplog.at_level(logging.WARNING):
+        result = ArtifactManager.resolve_recording_dir()
+        assert "record_videos" in str(result)
+        
+        # Should log warning for explicit environment override
+        assert len(caplog.records) == 1
+        record = caplog.records[0]
+        assert record.levelname == "WARNING"
+        assert "artifact.recording.legacy_path.forced" in record.__dict__.get('event', '')
+        assert "environment" in str(record.__dict__.get('override_source', ''))
+
+
+def test_resolve_recording_dir_warning_once_per_process(setup_test, caplog):
+    """Test warning is emitted only once per process."""
+    FeatureFlags.set_override("artifacts.unified_recording_path", False)
+    
+    with caplog.at_level(logging.WARNING):
+        # First call should warn
+        ArtifactManager.resolve_recording_dir()
+        assert len(caplog.records) == 1
+        
+        # Second call should not warn again
+        ArtifactManager.resolve_recording_dir()
+        assert len(caplog.records) == 1

--- a/tests/test_feature_flags.py
+++ b/tests/test_feature_flags.py
@@ -78,6 +78,91 @@ class TestFeatureFlags(unittest.TestCase):
         # Test undefined flag
         self.assertIsNone(FeatureFlags.get_override_source("nonexistent.flag"))
 
+    def test_get_override_source_env_parsing(self):
+        """Test environment variable parsing in get_override_source."""
+        # Test boolean parsing
+        os.environ["BYKILT_FLAG_TEST_BOOL"] = "true"
+        try:
+            FeatureFlags.reload()
+            self.assertEqual(FeatureFlags.get_override_source("test_bool"), "environment")
+        finally:
+            del os.environ["BYKILT_FLAG_TEST_BOOL"]
+            FeatureFlags.reload()
+
+        # Test integer parsing
+        os.environ["BYKILT_FLAG_TEST_INT"] = "42"
+        try:
+            FeatureFlags.reload()
+            self.assertEqual(FeatureFlags.get_override_source("test_int"), "environment")
+        finally:
+            del os.environ["BYKILT_FLAG_TEST_INT"]
+            FeatureFlags.reload()
+
+        # Test string parsing
+        os.environ["BYKILT_FLAG_TEST_STR"] = "custom_value"
+        try:
+            FeatureFlags.reload()
+            self.assertEqual(FeatureFlags.get_override_source("test_str"), "environment")
+        finally:
+            del os.environ["BYKILT_FLAG_TEST_STR"]
+            FeatureFlags.reload()
+
+    def test_coerce_method_coverage(self):
+        """Test _coerce method edge cases for better coverage."""
+        # Test boolean coercion from string
+        self.assertTrue(FeatureFlags._coerce("true", bool, "test"))
+        self.assertTrue(FeatureFlags._coerce("1", bool, "test"))
+        self.assertTrue(FeatureFlags._coerce("yes", bool, "test"))
+        self.assertTrue(FeatureFlags._coerce("on", bool, "test"))
+        self.assertFalse(FeatureFlags._coerce("false", bool, "test"))
+        self.assertFalse(FeatureFlags._coerce("0", bool, "test"))
+        self.assertFalse(FeatureFlags._coerce("no", bool, "test"))
+        self.assertFalse(FeatureFlags._coerce("off", bool, "test"))
+
+        # Test integer coercion
+        self.assertEqual(FeatureFlags._coerce("42", int, "test"), 42)
+        self.assertEqual(FeatureFlags._coerce(42, int, "test"), 42)
+
+        # Test string coercion
+        self.assertEqual(FeatureFlags._coerce(123, str, "test"), "123")
+        self.assertEqual(FeatureFlags._coerce("test", str, "test"), "test")
+
+        # Test None type (no coercion)
+        self.assertEqual(FeatureFlags._coerce("value", None, "test"), "value")
+
+    def test_prune_expired_overrides(self):
+        """Test _prune_expired method coverage."""
+        from datetime import datetime, timezone, timedelta
+
+        # Set an expired override
+        expired_time = datetime.now(timezone.utc) - timedelta(seconds=1)
+        FeatureFlags._overrides["test.expired"] = ("value", expired_time)
+
+        # Call prune (should remove expired override)
+        FeatureFlags._prune_expired()
+
+        # Verify expired override was removed
+        self.assertNotIn("test.expired", FeatureFlags._overrides)
+
+    def test_is_llm_enabled_function(self):
+        """Test is_llm_enabled backward compatibility function."""
+        from src.config.feature_flags import is_llm_enabled
+
+        # Test with feature flag
+        original_value = FeatureFlags.is_enabled("enable_llm")
+        try:
+            FeatureFlags.set_override("enable_llm", True)
+            self.assertTrue(is_llm_enabled())
+
+            FeatureFlags.set_override("enable_llm", False)
+            self.assertFalse(is_llm_enabled())
+        finally:
+            # Reset to original state
+            if original_value:
+                FeatureFlags.set_override("enable_llm", True)
+            else:
+                FeatureFlags.clear_override("enable_llm")
+
 
 if __name__ == "__main__":  # pragma: no cover
     unittest.main()

--- a/tests/test_feature_flags.py
+++ b/tests/test_feature_flags.py
@@ -58,6 +58,26 @@ class TestFeatureFlags(unittest.TestCase):
         finally:
             del os.environ["ENGINE_CDP_USE"]
 
+    def test_get_override_source(self):
+        # Test no override (file default)
+        self.assertIsNone(FeatureFlags.get_override_source("engine.cdp_use"))
+
+        # Test environment override
+        os.environ["BYKILT_FLAG_ENGINE_CDP_USE"] = "false"
+        try:
+            FeatureFlags.reload()
+            self.assertEqual(FeatureFlags.get_override_source("engine.cdp_use"), "environment")
+        finally:
+            del os.environ["BYKILT_FLAG_ENGINE_CDP_USE"]
+            FeatureFlags.reload()
+
+        # Test runtime override takes precedence
+        FeatureFlags.set_override("engine.cdp_use", True)
+        self.assertEqual(FeatureFlags.get_override_source("engine.cdp_use"), "runtime")
+
+        # Test undefined flag
+        self.assertIsNone(FeatureFlags.get_override_source("nonexistent.flag"))
+
 
 if __name__ == "__main__":  # pragma: no cover
     unittest.main()

--- a/tests/test_unified_recording_path_rollout.py
+++ b/tests/test_unified_recording_path_rollout.py
@@ -4,7 +4,7 @@ from src.runtime.run_context import RunContext
 
 
 def _legacy_msgs(caplog):
-    return [r.message for r in caplog.records if "Legacy recording path in use" in r.message]
+    return [r.message for r in caplog.records if "Legacy recording path" in r.message]
 
 
 def test_unified_recording_path_default_enabled(monkeypatch):


### PR DESCRIPTION
# Phase2-06: Artifacts 安定化 / 統合 — ランタイム検証の追記

このPRでは、録画パスの統一と録画アーティファクト（Tab-XX リネーム + tab_index_manifest.json 生成）を、browser-control と git-script の双方で実運転検証しました。下記にスモーク結果を追記します。

## 概要

- 録画パス統合: 環境変数 RECORDING_PATH を起点に統一（ArtifactManager/BrowserLauncher/NEW METHOD 全体で尊重）
- マルチタブ対応: 動的に生成されるタブごとに `Tab-XX-*.webm` へリネーム
- マニフェスト: `tab_index_manifest.json` を録画ディレクトリ直下に作成（動画の順序/ファイル/絶対パスを記録）

## スモーク検証結果（ローカル）

- browser-control（phrase-search）
  - 録画ディレクトリ: `artifacts/smoke/browser-control`
  - 生成動画: 2 本
    - 例: `Tab-01-bd6c94d0ac8d30c8bb694e3f64e23777.webm`（287,580 bytes）, `Tab-02-358fb1bff150c4a4b698814d3b4d59bc.webm`（16,940 bytes）
  - マニフェスト: `artifacts/smoke/browser-control/tab_index_manifest.json`（index 1..2 を付与）

- git-script（NEW METHOD）
  - 録画ディレクトリ: `artifacts/smoke/git-script`
  - 生成動画: 1 本（`f185a46d85253d8f988f5ffeb477905e.webm` 848,293 bytes）
  - マニフェスト: `artifacts/smoke/git-script/tab_index_manifest.json`

- 参考: ローカル最小テスト（ネットワーク非依存）
  - `myscript/local_selector_test.py` 実行で `.webm` を生成済（最小ケースでの録画成立を確認）

## 実装ポイント

- BrowserLauncher: `RECORDING_PATH` を確実に反映（persistent context / Chromium fallback 含む）
- NEW METHOD（git-script）: ProfileManager + BrowserLauncher で起動、録画強制、実行後に Tab-XX リネームとマニフェスト生成
- browser-control: コマンド実行 → 録画収集 → Tab-XX リネーム → マニフェスト生成の一連を整備
- 不具合修正: `direct_browser_control.py` 内部の `json` シャドーイングに起因する `UnboundLocalError` を解消

## 検証観点

- いずれのタイプ（browser-control / git-script）でも RECORDING_PATH 配下に `.webm` が作成されること
- マルチタブ時に `Tab-XX-*` へ正しくリネームされること（冪等性あり）
- `tab_index_manifest.json` が生成され、動画順序（index）とファイル/絶対パスが対応していること

## 残課題（フォローアップ候補）

- SonarCloud: 新規コードのカバレッジが 0% のため、最小ユニットテストの追加で改善予定
- マニフェストのスキーマ確定（必要なら docs 化）
- ローカル最小テストの継続整備（回帰検出用の軽量スモーク）

## 関連 Issue

- Closes #111
- Closes #110
- Closes #106
- Closes #104

## チェックリスト

- [x] browser-control で録画ファイル生成・マニフェスト生成を確認
- [x] git-script（NEW METHOD）で録画ファイル生成・マニフェスト生成を確認
- [x] ローカル最小テストで録画成立を確認
- [x] 既知のエラー（`json` シャドーイング）を解消
