### PR TITLE
ci(roadmap): auto-delete bot/roadmap-sync branches after PR merge

### DIFF
--- a/.github/workflows/update-issue-dependencies.yml
+++ b/.github/workflows/update-issue-dependencies.yml
@@ -78,6 +78,7 @@ jobs:
           branch: bot/roadmap-sync/${{ github.run_id }}
           title: "chore(roadmap): auto enrich ISSUE_DEPENDENCIES ${{ steps.date.outputs.date }}"
           commit-message: "chore(roadmap): auto enrich ISSUE_DEPENDENCIES (Issue #76)"
+          delete-branch: true
           body: |
             Automated enrichment (Issue #76 Phase 2).
 


### PR DESCRIPTION
概要

この PR は、Issue #76 に関連する自動化ワークフローが作成するブランチ `bot/roadmap-sync/*` を PR マージ後に自動削除するように変更します。

変更点

- `.github/workflows/update-issue-dependencies.yml` の `peter-evans/create-pull-request@v6` 呼び出しに `delete-branch: true` を追加

理由

- 現在、ワークフローは `bot/roadmap-sync/${{ github.run_id }}` のような一時ブランチを作成して PR を作成しますが、マージ後にブランチが残り続け、リモートに大量の `bot/roadmap-sync/*` ブランチが蓄積されます。
- `delete-branch: true` を指定することで、PR がマージされた際に自動でブランチを削除し、リモートのノイズを削減します。

検証方法

1. ワークフローを実行して差分が検出される状態にする（dry-run が変更を検出して apply を実行する）
2. 作成された PR がマージされた後、`origin` に `bot/roadmap-sync/<run_id>` ブランチが残らないことを確認

互換性/注意点

- `peter-evans/create-pull-request@v6` の `delete-branch` 入力は、このバージョンでサポートされています。ただし、異なるアクションバージョンや将来の変更により挙動が変わる可能性がある点に注意してください。
- ブランチが削除されるのは PR がマージされた場合のみです。マージされずクローズされた PR の場合は削除されない設定です（必要であれば、クローズ時も削除する別の cleanup ワークフローを追加できます）。

レビューとマージ

- 内容が問題なければこの PR をマージしてください。マージ後、ワークフローは生成ブランチを自動削除します。
