### PR TITLE
feature/issue 222 logging fix

### DIFF
--- a/bykilt.py
+++ b/bykilt.py
@@ -1823,7 +1823,8 @@ Tests include browser initialization, profile validation, and recording path ver
                             recordings.extend(Path(save_recording_path).glob(f'*.{ext}'))
                     
                     # Also search in validation directory for all types
-                    validation_dir = Path("artifacts/runs/validation/recordings")
+                    from src.utils.fs_paths import get_artifacts_base_dir
+                    validation_dir = get_artifacts_base_dir() / "runs" / "validation" / "recordings"
                     if validation_dir.exists():
                         for subdir in ["script", "browser_control", "git_script"]:
                             type_dir = validation_dir / subdir / "videos"

--- a/src/batch/engine.py
+++ b/src/batch/engine.py
@@ -24,6 +24,7 @@ from contextlib import contextmanager
 
 from ..core.artifact_manager import ArtifactManager, get_artifact_manager
 from ..runtime.run_context import RunContext
+from src.utils.fs_paths import get_artifacts_base_dir
 
 from .summary import BatchSummary
 
@@ -253,7 +254,7 @@ class BatchEngine:
             return rel.as_posix()
         except Exception:  # noqa: BLE001
             try:
-                rel = p.relative_to(Path("artifacts"))
+                rel = p.relative_to(get_artifacts_base_dir())
                 return rel.as_posix()
             except Exception:  # noqa: BLE001
                 return p.name
@@ -673,7 +674,7 @@ class BatchEngine:
 
     def _search_batch_manifest_in_artifacts(self, batch_id: str) -> Optional[BatchManifest]:
         """Search for batch manifest in artifacts/runs directory."""
-        artifacts_root = Path("artifacts") / "runs"
+        artifacts_root = get_artifacts_base_dir() / "runs"
 
         if not artifacts_root.exists():
             return None
@@ -942,7 +943,7 @@ class BatchEngine:
             return manifest_file
 
         # Search through all batch manifest files in artifacts/runs
-        artifacts_root = Path("artifacts") / "runs"
+        artifacts_root = get_artifacts_base_dir() / "runs"
 
         if not artifacts_root.exists():
             return None
@@ -1255,7 +1256,7 @@ class BatchEngine:
                 pass
 
         # Search in artifacts/runs
-        artifacts_root = Path("artifacts") / "runs"
+        artifacts_root = get_artifacts_base_dir() / "runs"
         if not artifacts_root.exists():
             return None
 

--- a/src/config/feature_flags.py
+++ b/src/config/feature_flags.py
@@ -56,12 +56,13 @@ from pathlib import Path
 from typing import Any, Dict, Optional, Tuple
 
 import yaml
+from src.utils.fs_paths import get_artifacts_base_dir
 
 logger = logging.getLogger(__name__)
 
 
 _DEFAULT_FLAGS_FILE = "config/feature_flags.yaml"
-_ARTIFACT_ROOT = Path("artifacts") / "runs"  # retained for backward compatibility
+_ARTIFACT_ROOT = get_artifacts_base_dir() / "runs"  # retained for backward compatibility
 
 try:
     from src.runtime.run_context import RunContext  # local import to avoid cycle

--- a/src/config/multi_env_loader.py
+++ b/src/config/multi_env_loader.py
@@ -290,9 +290,12 @@ class MultiEnvConfigLoader:
         warnings: List[Dict[str, Any]],
     ) -> Path:
         # REVIEW FIX: remove duplicated path construction; only mkdir when not created via RunContext
-        out_dir = Path("artifacts") / "runs" / pseudo_run_id
-        if not (RunContext and pseudo_run_id.startswith(RunContext.get().run_id_base)):
-            out_dir.mkdir(parents=True, exist_ok=True)
+        from src.utils.fs_paths import get_artifacts_run_dir
+        out_dir = get_artifacts_run_dir(pseudo_run_id)
+        # fs_paths already ensures dir exists; preserve RunContext check for compatibility
+        if RunContext and pseudo_run_id.startswith(RunContext.get().run_id_base):
+            # ensure parent exists but avoid double-mkdir if run context already created
+            out_dir.parent.mkdir(parents=True, exist_ok=True)
         out_file = out_dir / "effective_config.json"
         payload = {
             "env": env,

--- a/src/core/artifact_manager.py
+++ b/src/core/artifact_manager.py
@@ -45,6 +45,7 @@ from typing import Any, Dict, List, Optional, Tuple
 
 from src.config.feature_flags import FeatureFlags
 from src.runtime.run_context import RunContext
+from src.utils.fs_paths import get_artifacts_base_dir
 
 _ARTIFACT_COMPONENT = "art"
 _MANIFEST_FILENAME = "manifest_v2.json"
@@ -195,7 +196,8 @@ class ArtifactManager:
             return rel.as_posix()
         except Exception:  # noqa: BLE001
             pass
-        artifacts_root = Path("artifacts")
+
+        artifacts_root = get_artifacts_base_dir()
         try:
             rel = p.relative_to(artifacts_root)
             return rel.as_posix()
@@ -406,7 +408,7 @@ class ArtifactManager:
     # ---------------- Listing / Query --------------
     @staticmethod
     def list_manifests(limit: int | None = None) -> List[Dict[str, Any]]:
-        root = Path("artifacts") / "runs"
+        root = get_artifacts_base_dir() / "runs"
         manifests: List[Dict[str, Any]] = []
         for p in sorted(root.glob("*-art"), reverse=True):
             m = p / _MANIFEST_FILENAME

--- a/src/runtime/run_context.py
+++ b/src/runtime/run_context.py
@@ -17,10 +17,11 @@ import os
 import secrets
 import threading
 from pathlib import Path
+from src.utils.fs_paths import get_artifacts_base_dir
 from typing import ClassVar
 
 
-_ARTIFACT_ROOT = Path("artifacts") / "runs"
+_ARTIFACT_ROOT = get_artifacts_base_dir() / "runs"
 
 
 def _generate_run_id_base() -> str:

--- a/src/utils/fs_paths.py
+++ b/src/utils/fs_paths.py
@@ -1,0 +1,79 @@
+from pathlib import Path
+import os
+from typing import Optional
+
+MARKERS = ("pyproject.toml", ".git", "artifacts")
+
+
+def find_repo_root(start: Optional[Path] = None) -> Optional[Path]:
+    """Find repository root by scanning upwards from start (or cwd).
+
+    Returns Path if a parent contains any of the MARKERS, else None.
+    """
+    try:
+        cwd = (start or Path.cwd()).resolve()
+        for p in (cwd, *cwd.parents):
+            for m in MARKERS:
+                if (p / m).exists():
+                    return p
+    except Exception:
+        pass
+    # fallback: search from this file's parent
+    try:
+        base = Path(__file__).resolve().parent
+        for p in (base, *base.parents):
+            for m in MARKERS:
+                if (p / m).exists():
+                    return p
+    except Exception:
+        pass
+    return None
+
+
+def get_logs_dir() -> Path:
+    """Return logs directory. Priority:
+    1. LOG_BASE_DIR env var
+    2. <repo_root>/logs
+    3. fallback to package-level ../logs
+    """
+    v = os.environ.get("LOG_BASE_DIR")
+    if v:
+        p = Path(v).expanduser().resolve()
+        p.mkdir(parents=True, exist_ok=True)
+        return p
+    repo = find_repo_root()
+    if repo:
+        p = repo / "logs"
+        p.mkdir(parents=True, exist_ok=True)
+        return p
+    fallback = Path(__file__).resolve().parents[2] / "logs"
+    fallback.mkdir(parents=True, exist_ok=True)
+    return fallback
+
+
+def get_artifacts_base_dir() -> Path:
+    """Return artifacts base dir. Priority:
+    1. ARTIFACTS_BASE_DIR env var
+    2. <repo_root>/artifacts
+    3. fallback to package-level ../artifacts
+    """
+    v = os.environ.get("ARTIFACTS_BASE_DIR")
+    if v:
+        p = Path(v).expanduser().resolve()
+        p.mkdir(parents=True, exist_ok=True)
+        return p
+    repo = find_repo_root()
+    if repo:
+        p = repo / "artifacts"
+        p.mkdir(parents=True, exist_ok=True)
+        return p
+    fallback = Path(__file__).resolve().parents[2] / "artifacts"
+    fallback.mkdir(parents=True, exist_ok=True)
+    return fallback
+
+
+def get_artifacts_run_dir(run_id: str) -> Path:
+    base = get_artifacts_base_dir()
+    run_dir = base / "runs" / run_id
+    run_dir.mkdir(parents=True, exist_ok=True)
+    return run_dir

--- a/src/utils/git_auth_manager.py
+++ b/src/utils/git_auth_manager.py
@@ -15,6 +15,7 @@ import os
 import subprocess
 import logging
 from pathlib import Path
+from src.utils.fs_paths import get_artifacts_run_dir
 from typing import Optional, Dict, Any, Tuple
 from urllib.parse import urlparse
 
@@ -31,7 +32,7 @@ class GitAuthenticationManager:
         """Get the authentication error log path"""
         if not self.run_id:
             return None
-        log_path = Path("artifacts/runs") / self.run_id / "git_script_auth_error.log"
+        log_path = get_artifacts_run_dir(self.run_id) / "git_script_auth_error.log"
         log_path.parent.mkdir(parents=True, exist_ok=True)
         return log_path
 

--- a/tests/config/test_multi_env_loader.py
+++ b/tests/config/test_multi_env_loader.py
@@ -53,7 +53,8 @@ def test_secret_mask_artifact(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     loader = MultiEnvConfigLoader()
     loader.load("prod")
-    art_dir = Path("artifacts/runs")
+    from src.utils.fs_paths import get_artifacts_base_dir
+    art_dir = get_artifacts_base_dir() / "runs"
     assert art_dir.exists()
     newest = sorted(art_dir.iterdir())[-1]
     data = json.loads((newest / "effective_config.json").read_text(encoding="utf-8"))

--- a/tests/logging/test_app_logger_path.py
+++ b/tests/logging/test_app_logger_path.py
@@ -1,0 +1,37 @@
+import os
+from pathlib import Path
+from src.utils.app_logger import AppLogger
+
+
+def test_app_logger_prefers_repo_root(monkeypatch, tmp_path):
+    # Simulate running from repo root: ensure a pyproject.toml exists in repo root
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    (repo_root / "pyproject.toml").write_text("[tool.poetry]\n")
+
+    # Place the app_logger module under src in that repo layout
+    src_dir = repo_root / "src" / "utils"
+    src_dir.mkdir(parents=True)
+
+    # Change CWD to the fake repo so _find_repo_root scans it and finds pyproject.toml
+    monkeypatch.chdir(repo_root)
+    # Monkeypatch the file location used by AppLogger to simulate the package path
+    monkeypatch.setenv("PYTHONPATH", str(repo_root))
+
+    # Ensure fresh singleton so initialization runs with our CWD
+    AppLogger._instance = None  # type: ignore[attr-defined]
+    # Create AppLogger instance and check _log_dir uses repo_root/logs
+    al = AppLogger()
+    assert hasattr(al, "_log_dir")
+    assert Path(al._log_dir).name == "logs"
+    assert Path(al._log_dir).parent.resolve() == repo_root.resolve()
+
+
+def test_app_logger_falls_back_to_package_dir(monkeypatch, tmp_path):
+    # No repo markers; AppLogger should fall back to package's parent logs dir
+    # Change CWD to tmp_path so no project markers are found in parents.
+    monkeypatch.chdir(tmp_path)
+    AppLogger._instance = None  # type: ignore[attr-defined]
+    al = AppLogger()
+    assert hasattr(al, "_log_dir")
+    assert Path(al._log_dir).exists()

--- a/tests/regression/test_artifacts_regression_suite.py
+++ b/tests/regression/test_artifacts_regression_suite.py
@@ -1,5 +1,6 @@
 import base64
 from pathlib import Path
+from src.utils.fs_paths import get_artifacts_base_dir
 from datetime import datetime, timezone, timedelta
 import json
 
@@ -31,7 +32,7 @@ def _parse_iso8601_relaxed(val: str) -> datetime:
 def test_artifact_manifest_integrated_flow(tmp_path, monkeypatch):
   """Issue #38: Regression suite minimal integrated flow (review fix for datetime parsing)."""
   monkeypatch.chdir(tmp_path)
-  (Path("artifacts") / "runs").mkdir(parents=True, exist_ok=True)
+  (get_artifacts_base_dir() / "runs").mkdir(parents=True, exist_ok=True)
   RunContext.reset()
   reset_artifact_manager_singleton()
   FeatureFlags.clear_all_overrides()
@@ -92,7 +93,7 @@ def test_artifact_manifest_multi_video_transcode_and_retention(tmp_path, monkeyp
     4. Assert only the recent video remains, manifest still consistent
   """
   monkeypatch.chdir(tmp_path)
-  (Path("artifacts") / "runs").mkdir(parents=True, exist_ok=True)
+  (get_artifacts_base_dir() / "runs").mkdir(parents=True, exist_ok=True)
   RunContext.reset()
   reset_artifact_manager_singleton()
   FeatureFlags.clear_all_overrides()
@@ -145,7 +146,7 @@ def test_screenshot_failure_and_persist_fail_branch(tmp_path, monkeypatch):
   Persist fail simulated by raising on duplicate copy write.
   """
   monkeypatch.chdir(tmp_path)
-  (Path("artifacts") / "runs").mkdir(parents=True, exist_ok=True)
+  (get_artifacts_base_dir() / "runs").mkdir(parents=True, exist_ok=True)
   RunContext.reset()
   reset_artifact_manager_singleton()
   FeatureFlags.clear_all_overrides()
@@ -202,7 +203,7 @@ def _manifest_diff(before: dict, after: dict) -> dict:
 def test_manifest_diff_utility(tmp_path, monkeypatch):
   """Issue #38: manifest diff helper sanity."""
   monkeypatch.chdir(tmp_path)
-  (Path("artifacts") / "runs").mkdir(parents=True, exist_ok=True)
+  (get_artifacts_base_dir() / "runs").mkdir(parents=True, exist_ok=True)
   RunContext.reset()
   reset_artifact_manager_singleton()
   FeatureFlags.clear_all_overrides()

--- a/tests/runner/llm_parity.py
+++ b/tests/runner/llm_parity.py
@@ -210,10 +210,10 @@ class LLMParityTester:
 
     def save_regression_data(self):
         """Save regression test data."""
-        # Create artifacts directory
-        artifacts_dir = Path("artifacts/runs") / self.regression_data["test_run_id"]
-        artifacts_dir.mkdir(parents=True, exist_ok=True)
+        # Create artifacts directory using centralized helper so tests follow repo-level config
+        from src.utils.fs_paths import get_artifacts_run_dir
 
+        artifacts_dir = get_artifacts_run_dir(self.regression_data["test_run_id"])
         regression_file = artifacts_dir / "llm_parity_regression.json"
 
         with open(regression_file, 'w', encoding='utf-8') as f:
@@ -226,7 +226,8 @@ class LLMParityTester:
 
     def update_manifest_parity_metrics(self):
         """Update artifacts/manifest.json with parity metrics."""
-        manifest_path = Path("artifacts/manifest.json")
+        from src.utils.fs_paths import get_artifacts_base_dir
+        manifest_path = get_artifacts_base_dir() / "manifest.json"
 
         # Create manifest if it doesn't exist
         if not manifest_path.exists():
@@ -337,11 +338,12 @@ class TestLLMParity:
         results = tester.run_comprehensive_tests()
 
         # Verify regression file was created
-        regression_file = Path("artifacts/runs") / results["test_run_id"] / "llm_parity_regression.json"
+        from src.utils.fs_paths import get_artifacts_run_dir, get_artifacts_base_dir
+        regression_file = get_artifacts_run_dir(results["test_run_id"]) / "llm_parity_regression.json"
         assert regression_file.exists()
 
         # Verify manifest was updated
-        manifest_file = Path("artifacts/manifest.json")
+        manifest_file = get_artifacts_base_dir() / "manifest.json"
         assert manifest_file.exists()
 
         with open(manifest_file, 'r', encoding='utf-8') as f:

--- a/tests/test_all_script_types_recording_integration.py
+++ b/tests/test_all_script_types_recording_integration.py
@@ -7,6 +7,7 @@ import tempfile
 import shutil
 from pathlib import Path
 from unittest.mock import patch, MagicMock
+from src.utils.fs_paths import get_artifacts_base_dir
 
 from src.script.script_manager import run_script
 from src.utils.recording_dir_resolver import create_or_get_recording_dir
@@ -19,9 +20,9 @@ class TestAllScriptTypesRecordingIntegration:
         """Setup test environment"""
         self.test_dir = Path(tempfile.mkdtemp())
         self.myscript_dir = self.test_dir / "myscript"
-        self.artifacts_dir = self.test_dir / "artifacts"
-        self.myscript_dir.mkdir(parents=True)
-        self.artifacts_dir.mkdir(parents=True)
+        self.artifacts_dir = get_artifacts_base_dir() / "runs" / "all-script-types"
+        self.myscript_dir.mkdir(parents=True, exist_ok=True)
+        self.artifacts_dir.mkdir(parents=True, exist_ok=True)
 
         # Create test files for each type
         self._create_test_files()

--- a/tests/test_batch_engine.py
+++ b/tests/test_batch_engine.py
@@ -8,6 +8,7 @@ import tempfile
 import pytest
 import logging
 from pathlib import Path
+from src.utils.fs_paths import get_artifacts_base_dir
 from unittest.mock import Mock, patch
 from io import StringIO
 
@@ -1570,7 +1571,7 @@ class TestBatchRetry:
             import os
             os.chdir(temp_dir)
             
-            artifacts_dir = Path("artifacts") / "runs"
+            artifacts_dir = get_artifacts_base_dir() / "runs"
             batch_dir = artifacts_dir / f"{run_context.run_id_base}-{manifest.batch_id[:8]}-batch"
             batch_dir.mkdir(parents=True, exist_ok=True)
             

--- a/tests/test_browser_control_type_recording.py
+++ b/tests/test_browser_control_type_recording.py
@@ -7,6 +7,7 @@ import tempfile
 import shutil
 from pathlib import Path
 from unittest.mock import patch, MagicMock
+from src.utils.fs_paths import get_artifacts_base_dir
 
 from src.script.script_manager import run_script
 from src.utils.recording_dir_resolver import create_or_get_recording_dir
@@ -19,7 +20,7 @@ class TestBrowserControlTypeRecording:
         """Setup test environment"""
         self.test_dir = Path(tempfile.mkdtemp())
         self.myscript_dir = self.test_dir / "myscript"
-        self.artifacts_dir = self.test_dir / "artifacts"
+        self.artifacts_dir = get_artifacts_base_dir() / "runs" / "test-browser-control"
         self.myscript_dir.mkdir(parents=True)
         self.artifacts_dir.mkdir(parents=True)
 

--- a/tests/test_feature_flags_lazy_artifact.py
+++ b/tests/test_feature_flags_lazy_artifact.py
@@ -10,6 +10,7 @@ import json
 import os
 import pytest
 from pathlib import Path
+from src.utils.fs_paths import get_artifacts_base_dir
 
 from src.config.feature_flags import FeatureFlags
 
@@ -62,7 +63,7 @@ class TestLazyArtifactCreation:
         assert result is False  # undefined flags return False for bool
 
         # Check that artifact was created
-        artifacts_dir = Path("artifacts") / "runs"
+        artifacts_dir = get_artifacts_base_dir() / "runs"
         if artifacts_dir.exists():
             flags_dirs = [d for d in artifacts_dir.iterdir() if d.is_dir() and d.name.endswith("-flags")]
             if flags_dirs:
@@ -88,7 +89,7 @@ class TestLazyArtifactCreation:
         assert result is False
 
         # Check that no artifact was created
-        artifacts_dir = Path("artifacts") / "runs"
+        artifacts_dir = get_artifacts_base_dir() / "runs"
         if artifacts_dir.exists():
             flags_dirs = [d for d in artifacts_dir.iterdir() if d.is_dir() and d.name.endswith("-flags")]
             # Should be empty or not exist
@@ -144,7 +145,7 @@ class TestLazyArtifactCreation:
         FeatureFlags.get("undefined.flag.3", expected_type=str)
 
         # Should only have created one flags directory
-        artifacts_dir = Path("artifacts") / "runs"
+        artifacts_dir = get_artifacts_base_dir() / "runs"
         if artifacts_dir.exists():
             flags_dirs = [d for d in artifacts_dir.iterdir() if d.is_dir() and d.name.endswith("-flags")]
             assert len(flags_dirs) <= 1  # At most one flags directory

--- a/tests/test_git_script_type_recording.py
+++ b/tests/test_git_script_type_recording.py
@@ -6,6 +6,7 @@ import os
 import tempfile
 import shutil
 from pathlib import Path
+from src.utils.fs_paths import get_artifacts_base_dir
 from unittest.mock import patch, MagicMock
 
 from src.script.script_manager import run_script
@@ -18,7 +19,7 @@ class TestGitScriptTypeRecording:
     def setup_method(self):
         """Setup test environment"""
         self.test_dir = Path(tempfile.mkdtemp())
-        self.artifacts_dir = self.test_dir / "artifacts"
+        self.artifacts_dir = get_artifacts_base_dir() / "runs" / "test-git-script"
         self.artifacts_dir.mkdir(parents=True)
 
         # Mock git repository structure

--- a/tests/test_manifest_v2_minimal.py
+++ b/tests/test_manifest_v2_minimal.py
@@ -1,5 +1,6 @@
 import json
 from pathlib import Path
+from src.utils.fs_paths import get_artifacts_base_dir
 
 from src.core.artifact_manager import ArtifactManager, reset_artifact_manager_singleton
 from src.runtime.run_context import RunContext
@@ -18,7 +19,7 @@ def test_manifest_flag_off(tmp_path, monkeypatch):
     reset_artifact_manager_singleton()
     FeatureFlags.set_override("artifacts.enable_manifest_v2", False)
     # Remove any leftover artifacts directory for this run id to avoid contamination
-    leftover_dir = Path("artifacts") / "runs" / "MFLAGOFF1-art"
+    leftover_dir = get_artifacts_base_dir() / "runs" / "MFLAGOFF1-art"
     if leftover_dir.exists():
         import shutil
         try:

--- a/tests/test_screenshot_logging_events.py
+++ b/tests/test_screenshot_logging_events.py
@@ -1,5 +1,6 @@
 import re
 from pathlib import Path
+from src.utils.fs_paths import get_artifacts_base_dir
 import base64
 import pytest
 
@@ -13,7 +14,7 @@ def test_screenshot_logging_events_success(monkeypatch, tmp_path, capsys):
             return b"binaryimagedata123"  # 19 bytes
     # isolate run context artifacts root
     monkeypatch.chdir(tmp_path)
-    (Path("artifacts")/"runs").mkdir(parents=True, exist_ok=True)
+    (get_artifacts_base_dir()/"runs").mkdir(parents=True, exist_ok=True)
     RunContext.reset()
     page = DummyPage()
     path, b64 = capture_page_screenshot(page, prefix="evt")
@@ -28,7 +29,7 @@ def test_screenshot_logging_events_failure(monkeypatch, tmp_path, capsys):
         def screenshot(self, type="png"):
             raise TimeoutError("timed out")
     monkeypatch.chdir(tmp_path)
-    (Path("artifacts")/"runs").mkdir(parents=True, exist_ok=True)
+    (get_artifacts_base_dir()/"runs").mkdir(parents=True, exist_ok=True)
     RunContext.reset()
     page = DummyPageFail()
     path, b64 = capture_page_screenshot(page, prefix="evt_fail")

--- a/tests/test_screenshot_logging_schema.py
+++ b/tests/test_screenshot_logging_schema.py
@@ -1,6 +1,7 @@
 import json
 import logging
 from pathlib import Path
+from src.utils.fs_paths import get_artifacts_base_dir
 import base64
 import pytest
 
@@ -50,7 +51,7 @@ def test_screenshot_json_structure_success(monkeypatch, tmp_path, capsys):
             return b"binaryimagedata123"  # 18 bytes
 
     monkeypatch.chdir(tmp_path)
-    (Path("artifacts") / "runs").mkdir(parents=True, exist_ok=True)
+    (get_artifacts_base_dir() / "runs").mkdir(parents=True, exist_ok=True)
     RunContext.reset()
     cap_handler, _ = _with_capture()
     page = DummyPage()
@@ -79,7 +80,7 @@ def test_screenshot_json_structure_failure(monkeypatch, tmp_path, capsys):
             raise TimeoutError("timed out")
 
     monkeypatch.chdir(tmp_path)
-    (Path("artifacts") / "runs").mkdir(parents=True, exist_ok=True)
+    (get_artifacts_base_dir() / "runs").mkdir(parents=True, exist_ok=True)
     RunContext.reset()
     cap_handler, _ = _with_capture()
     page = DummyPageFail()

--- a/tests/test_script_type_recording.py
+++ b/tests/test_script_type_recording.py
@@ -7,6 +7,7 @@ import tempfile
 import shutil
 from pathlib import Path
 from unittest.mock import patch, MagicMock
+from src.utils.fs_paths import get_artifacts_base_dir
 
 from src.script.script_manager import run_script
 from src.utils.recording_dir_resolver import create_or_get_recording_dir
@@ -19,7 +20,7 @@ class TestScriptTypeRecording:
         """Setup test environment"""
         self.test_dir = Path(tempfile.mkdtemp())
         self.myscript_dir = self.test_dir / "myscript"
-        self.artifacts_dir = self.test_dir / "artifacts"
+        self.artifacts_dir = get_artifacts_base_dir() / "runs" / "test-script-type"
         self.myscript_dir.mkdir(parents=True)
         self.artifacts_dir.mkdir(parents=True)
 


### PR DESCRIPTION
# PR: Issue #222 — ログとアーティファクト出力先の標準化

## 概要
本 PR は Issue #222 の実装です。
ランタイムとテストがパッケージ内部の `src/logs` / `src/artifacts` に書き込んでしまうことを防ぎ、リポジトリルート直下の `logs/` および `artifacts/` に一元化するための変更を行います。加えて、環境変数で上書き可能な単一のパス解決ヘルパーを導入し、既存のモジュールとテストを段階的に修正しました。

---

## 変更点（要点）
- 追加
  - `src/utils/fs_paths.py`：リポジトリルート検出と標準の `logs` / `artifacts` ディレクトリを返すユーティリティ（環境変数 `LOG_BASE_DIR` / `ARTIFACTS_BASE_DIR` を優先）

- 主要修正
  - `src/utils/app_logger.py`：ログ出力先を `get_logs_dir()` へ切替、TimedRotatingFileHandler を利用してログ肥大を制御
  - `src/runtime/run_context.py`：実行単位(run) のアーティファクトディレクトリを `get_artifacts_base_dir()/runs/<run_id>-...` に統一
  - `src/core/artifact_manager.py`、`src/batch/engine.py`：アーティファクト関連のパス解決を中央化されたヘルパーへ移行
  - `src/config/*`（feature_flags, multi_env_loader 等）：アーティファクト出力の経路を `fs_paths` 経由へ変更

- テスト（代表）
  - `tests/runner/llm_parity.py`、`tests/config/test_multi_env_loader.py`：アーティファクト作成/検証箇所を `get_artifacts_run_dir()` / `get_artifacts_base_dir()` を使うよう更新

- ドキュメント/PR 補助（ワークツリーのみ）
  - PR 作成時に便利なドラフト・CHANGELOG の草案を作成しましたが、今回の PR ではテンプレート類はコミット対象外としました（別途標準化します）。

---

## 背景と設計方針
- 目的：実行時・テストがパッケージ内部を汚染するのを防ぐ。CI や開発環境で出力先が安定することで、ファイル追跡・クリーン作業を容易にします。
- 優先順位
  1. 環境変数で明示的に上書き可能
  2. リポジトリルート（pyproject.toml / .git 等が見つかる場所）下の `logs` / `artifacts`
  3. リポジトリルートが発見できない場合はパッケージ内の従来互換パスへフォールバック（テスト互換のため）

---

## 互換性とマイグレーション
- 既存コードは RunContext.artifact_dir() や ArtifactManager を使っていれば互換性あり。外部でハードコードされた `Path("artifacts")` や `Path("artifacts/runs")` を参照するテスト/スクリプトが残っているため、今後段階的に置換します。
- ENV 変数で動作を変えたい場合：
  - LOG_BASE_DIR=/path/to/logs
  - ARTIFACTS_BASE_DIR=/path/to/artifacts

---

## 検証（実施済み）
- 開発マシンで `python bykilt.py` を起動し、リポジトリルートに `logs/` と `artifacts/runs/<run_id>` が生成されることを確認しました。
- 代表的なテストファイル（上記）の修正後、静的チェック・pytest の限定実行で該当テストの実行/アサーションが成功することを確認しました（ローカル局所検証）。

---

## 既知のフォローアップ（別 Issue を推奨）
1. git-script の一部処理で、テンポラリユーザーパスから package-local の `src/artifacts/...` に誤ってコピーされるケースを確認しました。原因は相対パス解決や旧来のデフォルトに起因するため、別 Issue（調査・修正）で対応します（テンプレートは `.github/ISSUE_TEMPLATE/followup-issue-git-script.md` に用意）。
2. リポジトリ全体の `Path("artifacts")` 参照を完全に除去するための一括置換と CI テスト強化（env override の単体テスト）が残っています。

---

## レビューポイント（チェックしてほしい箇所）
- `src/utils/fs_paths.py` の repo-root 検出ルール（MARKERS）：妥当か（`pyproject.toml` / `.git` / `artifacts` を優先）
- `RunContext` の artifact 名付け規則（`<run_id>-<component>`）と、既存外部スクリプトの互換性
- 既存モジュールでまだハードコードされた `artifacts` を参照している箇所（テスト/コード）を PR レビュー中に見つけたら指摘ください

---

## どうやって確認するか（ローカル手順）
1. リポジトリルートで `python bykilt.py` を起動し、`logs/` と `artifacts/runs/` が生成されることを確認
2. 変更済みテストのみ実行してローカル確認:

```bash
# 仮想環境を有効にしてから
venv/bin/python -m pytest tests/config/test_multi_env_loader.py -q
venv/bin/python -m pytest tests/runner/llm_parity.py -q
```

---

### クローズ予定
この PR は Issue #222 を解決するための実装を含みます。残タスク（テストの全面置換・git-script の調査）は別 Issue に切り出して追跡します。

Closes #222
