### PR TITLE
feat: add recordings service and associated tests for listing functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -254,3 +254,5 @@ artifacts/metrics/*.csv
 
 # Temporary files for recording under src/artifacts
 src/artifacts/**
+
+.gh/**

--- a/src/services/__init__.py
+++ b/src/services/__init__.py
@@ -1,0 +1,10 @@
+"""Service layer package for domain-specific orchestration."""
+
+from .recordings_service import ListParams, RecordingItemDTO, RecordingsPage, list_recordings
+
+__all__ = [
+    "ListParams",
+    "RecordingItemDTO",
+    "RecordingsPage",
+    "list_recordings",
+]

--- a/src/services/recordings_service.py
+++ b/src/services/recordings_service.py
@@ -1,0 +1,174 @@
+"""Recordings service facade (Issue #304).
+
+Wraps the recordings scanner utility to provide a stable API surface for
+callers (UI/server). Handles pagination metadata, flag-aware fallback, and
+input validation before delegating to the scanner.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Generic, Iterable, List, Sequence, TypeVar
+
+from src.config.feature_flags import FeatureFlags
+from src.recordings.recordings_scanner import DEFAULT_EXTENSIONS, RecordingItem, scan_recordings
+from src.utils.recording_dir_resolver import create_or_get_recording_dir
+
+T = TypeVar("T")
+
+_FLAG_RECURSIVE_SCAN = "artifacts.recursive_recordings_enabled"
+_MAX_LIMIT = 200
+
+
+@dataclass(frozen=True, slots=True)
+class RecordingsPage(Generic[T]):
+    """Generic pagination container for recordings service responses."""
+
+    items: List[T]
+    limit: int
+    offset: int
+    has_next: bool
+
+
+@dataclass(frozen=True, slots=True)
+class RecordingItemDTO:
+    """DTO consumed by UI/API layers."""
+
+    path: str
+    size_bytes: int
+    modified_at: float
+    run_id: str | None
+
+
+@dataclass(frozen=True, slots=True)
+class ListParams:
+    """Input schema for ``list_recordings``."""
+
+    root: Path | None = None
+    limit: int = 50
+    offset: int = 0
+    allow_extensions: Sequence[str] | None = None
+    allowed_roots: Sequence[Path] | None = None
+
+
+def list_recordings(params: ListParams | None = None) -> RecordingsPage[RecordingItemDTO]:
+    """Return a page of recordings ordered by newest first."""
+
+    params = params or ListParams()
+
+    limit = params.limit
+    offset = params.offset
+
+    if limit < 0:
+        raise ValueError("limit must be non-negative")
+    if offset < 0:
+        raise ValueError("offset must be non-negative")
+    if limit > _MAX_LIMIT:
+        raise ValueError(f"limit must not exceed {_MAX_LIMIT}")
+
+    root = (params.root or create_or_get_recording_dir()).expanduser().resolve()
+
+    if not root.exists():
+        raise FileNotFoundError(f"Recordings root does not exist: {root}")
+    if not root.is_dir():
+        raise NotADirectoryError(f"Recordings root is not a directory: {root}")
+
+    allow_extensions = params.allow_extensions or DEFAULT_EXTENSIONS
+
+    if params.allowed_roots is None:
+        allowed_roots: Sequence[Path] = (root,)
+    else:
+        allowed_roots = tuple(Path(p).resolve() for p in params.allowed_roots)
+
+    _ensure_within_allowed_roots(root, allowed_roots)
+
+    fetch_limit = limit + 1 if limit > 0 else 1
+
+    if not FeatureFlags.is_enabled(_FLAG_RECURSIVE_SCAN):
+        iterator = _scan_flat(root, allow_extensions, limit=fetch_limit, offset=offset)
+    else:
+        iterator = scan_recordings(
+            root,
+            allow_extensions=allow_extensions,
+            limit=fetch_limit,
+            offset=offset,
+            allowed_roots=allowed_roots,
+        )
+
+    items = list(iterator)
+    has_next = _has_next(items, limit)
+    slice_limit = min(limit, len(items))
+    window = items[:slice_limit]
+
+    dto_items = [_to_dto(item) for item in window]
+
+    return RecordingsPage(items=dto_items, limit=limit, offset=offset, has_next=has_next)
+
+
+def _scan_flat(root: Path, allow_extensions: Sequence[str], *, limit: int, offset: int) -> Iterable[RecordingItem]:
+    """Basic non-recursive listing used when the flag is disabled."""
+
+    extensions = _normalise_extensions(allow_extensions)
+    entries: list[RecordingItem] = []
+
+    for entry in root.iterdir():
+        if not entry.is_file():
+            continue
+        if entry.suffix.lower() not in extensions:
+            continue
+        stats = entry.stat()
+        entries.append(RecordingItem(path=entry, size_bytes=stats.st_size, modified_at=stats.st_mtime))
+
+    entries.sort(key=lambda item: item.modified_at, reverse=True)
+    end = offset + limit if limit else None
+    window = entries[offset:end]
+    return window
+
+
+def _has_next(items: Sequence[RecordingItem], limit: int) -> bool:
+    if limit == 0:
+        return bool(items)
+    return len(items) > limit
+
+
+def _to_dto(item: RecordingItem) -> RecordingItemDTO:
+    return RecordingItemDTO(
+        path=str(item.path),
+        size_bytes=item.size_bytes,
+        modified_at=item.modified_at,
+        run_id=_infer_run_id(item.path),
+    )
+
+
+def _infer_run_id(path: Path) -> str | None:
+    parts = path.parts
+    for index, part in enumerate(parts):
+        if part == "runs" and index + 1 < len(parts):
+            candidate = parts[index + 1]
+            if candidate and candidate != "validation":
+                return candidate
+    return None
+
+
+def _ensure_within_allowed_roots(root: Path, allowed_roots: Sequence[Path]) -> None:
+    resolved = root.resolve()
+    for candidate in allowed_roots:
+        try:
+            if resolved.is_relative_to(candidate):
+                return
+        except ValueError:
+            continue
+    raise ValueError("root path escapes allowed roots whitelist")
+
+
+def _normalise_extensions(values: Sequence[str]) -> set[str]:
+    normalised: set[str] = set()
+    for ext in values:
+        if not ext:
+            continue
+        value = ext.lower()
+        if not value.startswith("."):
+            value = f".{value}"
+        normalised.add(value)
+    return normalised or {ext.lower() for ext in DEFAULT_EXTENSIONS}

--- a/tests/services/test_recordings_service.py
+++ b/tests/services/test_recordings_service.py
@@ -1,0 +1,164 @@
+from __future__ import annotations
+
+import os
+import time
+from pathlib import Path
+from typing import Iterator
+
+import pytest
+
+from src.config.feature_flags import FeatureFlags
+from src.services import recordings_service
+from src.services import ListParams, list_recordings
+
+_FLAG = "artifacts.recursive_recordings_enabled"
+
+
+@pytest.fixture(autouse=True)
+def _reset_flag_state() -> Iterator[None]:
+    FeatureFlags.reload()
+    FeatureFlags.clear_override(_FLAG)
+    yield
+    FeatureFlags.clear_override(_FLAG)
+
+
+def _touch(path: Path, *, mtime: float) -> None:
+    path.write_bytes(b"data")
+    os.utime(path, (mtime, mtime))
+
+
+def test_missing_root_raises_file_not_found(tmp_path: Path) -> None:
+    missing = tmp_path / "runs" / "missing"
+    params = ListParams(root=missing)
+    with pytest.raises(FileNotFoundError):
+        list_recordings(params)
+
+
+def test_limit_upper_bound_validation(tmp_path: Path) -> None:
+    root = tmp_path / "runs"
+    root.mkdir()
+    params = ListParams(root=root, limit=recordings_service._MAX_LIMIT + 1)
+    with pytest.raises(ValueError):
+        list_recordings(params)
+
+
+def test_flag_disabled_uses_flat_listing(tmp_path: Path) -> None:
+    root = tmp_path / "runs"
+    nested = root / "nested"
+    nested.mkdir(parents=True)
+
+    top_file = root / "top.webm"
+    nested_file = nested / "nested.webm"
+    now = time.time()
+    _touch(top_file, mtime=now)
+    _touch(nested_file, mtime=now + 5)
+
+    page = list_recordings(ListParams(root=root, limit=10))
+
+    assert [Path(item.path) for item in page.items] == [top_file]
+    assert not page.has_next
+
+
+def test_flag_enabled_lists_recursive(tmp_path: Path) -> None:
+    FeatureFlags.set_override(_FLAG, True)
+
+    root = tmp_path / "runs"
+    nested = root / "nested"
+    nested.mkdir(parents=True)
+
+    older = root / "older.mp4"
+    newer = nested / "newer.webm"
+    now = time.time()
+    _touch(older, mtime=now)
+    _touch(newer, mtime=now + 30)
+
+    page = list_recordings(ListParams(root=root, limit=10))
+
+    assert [Path(item.path) for item in page.items] == [newer, older]
+    assert not page.has_next
+
+
+def test_pagination_reports_more_items(tmp_path: Path) -> None:
+    root = tmp_path / "runs"
+    root.mkdir()
+
+    base = time.time()
+    files = []
+    for index in range(5):
+        current = root / f"file_{index}.webm"
+        _touch(current, mtime=base + index)
+        files.append(current)
+
+    page = list_recordings(ListParams(root=root, limit=2, offset=0))
+
+    assert [Path(item.path) for item in page.items] == files[-1:-3:-1]
+    assert page.has_next
+
+
+def test_zero_limit_returns_no_items_but_indicates_more(tmp_path: Path) -> None:
+    root = tmp_path / "runs"
+    root.mkdir()
+
+    sample = root / "sample.webm"
+    _touch(sample, mtime=time.time())
+
+    page = list_recordings(ListParams(root=root, limit=0))
+
+    assert page.items == []
+    assert page.has_next
+
+
+def test_extension_filtering(tmp_path: Path) -> None:
+    FeatureFlags.set_override(_FLAG, True)
+
+    root = tmp_path / "runs"
+    root.mkdir()
+
+    keep = root / "keep.CUSTOM"
+    drop = root / "drop.mp4"
+    now = time.time()
+    _touch(keep, mtime=now + 1)
+    _touch(drop, mtime=now)
+
+    page = list_recordings(ListParams(root=root, allow_extensions=("custom",)))
+
+    assert [Path(item.path) for item in page.items] == [keep]
+
+
+def test_allowed_roots_validation(tmp_path: Path) -> None:
+    root = tmp_path / "runs"
+    root.mkdir()
+    other = tmp_path / "other"
+    other.mkdir()
+
+    params = ListParams(root=root, allowed_roots=(other,))
+
+    with pytest.raises(ValueError):
+        list_recordings(params)
+
+
+def test_permission_error_bubbles(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    root = tmp_path / "runs"
+    root.mkdir()
+
+    def _raise(*_args, **_kwargs):
+        raise PermissionError("denied")
+
+    monkeypatch.setattr(recordings_service, "_scan_flat", _raise)
+
+    with pytest.raises(PermissionError):
+        list_recordings(ListParams(root=root, limit=1))
+
+
+def test_run_id_inference(tmp_path: Path) -> None:
+    FeatureFlags.set_override(_FLAG, True)
+
+    base = tmp_path / "artifacts" / "runs" / "20240101-abcd" / "videos"
+    base.mkdir(parents=True)
+    target = base / "clip.webm"
+    _touch(target, mtime=time.time())
+
+    params = ListParams(root=tmp_path / "artifacts" / "runs", limit=5)
+    page = list_recordings(params)
+
+    assert page.items[0].run_id == "20240101-abcd"


### PR DESCRIPTION
# 🎥 Recordings: 一覧取得サービス / API (Issue #304)

## 概要
本 PR は再帰探索ユーティリティ（Issue #303）を利用して、Recordings の一覧取得を行うサービス層を追加します。
UI や外部 API から利用しやすい安定した I/O（軽量 DTO）を提供し、Feature Flag による挙動分岐、ページング、拡張子フィルタ、入力バリデーションを実装しています。

## 目的
- 再帰スキャンのロジック（ユーティリティ）を直接 UI 側が扱わず、安定したサービス API を経由して取り扱えるようにする。
- Flag（`artifacts.recursive_recordings_enabled`）により既存のフラット走査へフォールバック可能にする。
- UI／外部 I/F に対して容易に利用できる DTO を提供することで、後続の UI 統合（Issue #305）を簡素化する。

## 変更点（ハイライト）
- 新規ファイル: `src/services/recordings_service.py`
  - `ListParams`（入力スキーマ: `root`, `limit`, `offset`, `allow_extensions`, `allowed_roots`）
  - `RecordingItemDTO`（出力 DTO: `path`, `size_bytes`, `modified_at`, `run_id`）
  - `RecordingsPage`（ページングコンテナ: `items`, `limit`, `offset`, `has_next`）
  - `list_recordings(params: ListParams) -> RecordingsPage[RecordingItemDTO]`（主要関数）
- パッケージ初期化: `src/services/__init__.py` にエクスポートを追加
- テスト: `tests/services/test_recordings_service.py`
  - フラグ制御、ページング、拡張子フィルタ、allowed_roots 検証、例外透過、run_id 推定 などを網羅

## 実装の要点
- Flag フォールバック
  - `artifacts.recursive_recordings_enabled` が `false` の場合は従来通りディレクトリ直下のみ走査（flat）します。
  - `true` の場合は `src/recordings/recordings_scanner.scan_recordings` を利用した再帰検出を用います。

- 入力検証
  - `limit`/`offset` は非負であることを検証します。
  - `limit` の上限を `_MAX_LIMIT = 200` に設定し、過大値は `ValueError` を返します。
  - `root` が存在しない場合は `FileNotFoundError`、ディレクトリでない場合は `NotADirectoryError` を返します。

- ページング
  - 内部で `limit + 1` 件を取得して `has_next` を判定します。
  - `limit=0` は「結果を返さないが、存在するかの判定は行う」挙動をテストで検証しています。

- 拡張子フィルタ
  - 大文字/小文字を問わず正規化して判定します。
  - 呼び出し側が `['mp4', 'custom']` のように拡張子だけ指定しても機能します（内部で `.` を付与します）。

- run_id 推定
  - パス要素から `.../runs/<run_id>/...` を検出して `run_id` を埋めます（UI 表示用の軽量ヒューリスティック）。

## I/O（契約）
- 入力: `ListParams`（
  - `root: Path | None` — 指定しない場合は `create_or_get_recording_dir()` にフォールバック
  - `limit: int = 50`
  - `offset: int = 0`
  - `allow_extensions: Sequence[str] | None`
  - `allowed_roots: Sequence[Path] | None`）

- 出力: `RecordingsPage[RecordingItemDTO]`（
  - `items: List[RecordingItemDTO]`
  - `limit: int`
  - `offset: int`
  - `has_next: bool`）

## テスト / 検証
- 追加したテスト `tests/services/test_recordings_service.py` は以下を検証しています:
  - フラグ OFF の場合は flat listing
  - フラグ ON の場合は再帰探索で新しい順ソート
  - `limit`/`offset` のウィンドウ挙動
  - `allowed_roots` のホワイトリスト検証
  - 拡張子フィルタ（大文字/小文字）
  - 例外（PermissionError 等）の透過
  - run_id のヒューリスティック推定

ローカル検証: `venv/bin/python -m pytest tests/services/test_recordings_service.py`（通過）

## 注意点 / 今後の対応
- `run_id` 推定は現状ヒューリスティック実装です。将来的に厳密な仕様が必要であれば改修予定。
- 既存の `bykilt.py` に残る旧実装は UI 移行フェーズ（Issue #305）で段階的に置換予定。

## 関連 Issue / PR
- 親: #302
- 依存: #303 (recordings scanner utility)
- PR（本 PR）: #309
- 参考: PR for #303 -> #308

---

ご確認ください。本文に補足したいスクリーンショットや追加の検証結果があれば教えてください。