### PR TITLE
docs: replace copilot-instructions with agent-optimized CLAUDE.md and project skills

### DIFF
--- a/.claude/skills/add-llms-action/SKILL.md
+++ b/.claude/skills/add-llms-action/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: add-llms-action
+description: Add or modify a pre-registered automation action in llms.txt — choosing the right action type (script, browser-control, git-script, unlock-future, action_runner_template), parameter syntax, schema validation, and how to test it without an LLM.
+---
+
+# Adding an action to llms.txt
+
+Actions in `llms.txt` are the LLM-free automation vocabulary of 2bykilt. They are matched against user prompts by `src/modules/command_dispatcher.py` before any LLM is consulted.
+
+## 1. Choose the action type
+
+| You want to… | Use type | Key fields |
+|---|---|---|
+| Run an existing pytest script with params | `script` | `script`, `command` |
+| Describe a click/fill/extract flow declaratively | `browser-control` | `flow:` list of steps |
+| Run a script that lives in another git repo | `git-script` | `git`, `script_path`, `version`, `command` |
+| JSON-based execution with tab control | `unlock-future` | `flow:`, `tab_selection_strategy`, `keep_tab_open` |
+| Reuse a parameterized template under `templates/` | `action_runner_template` | `template`, `command` |
+
+Flow steps available in `browser-control`/`unlock-future`: `command` (navigate; `url`, `wait_until`/`wait_for`), `click`, `fill_form`, `keyboard_press`, `scroll_to_bottom`, `screenshot` (`prefix`, `full_page`), `extract_content` (`selectors` with optional `label`/`fields`).
+
+## 2. Declare parameters
+
+```yaml
+params:
+  - name: query
+    required: true
+    type: string
+    description: "Search query to execute"
+```
+
+Reference them as `${params.query}`; defaults use pipe syntax: `${params.browser|chromium}`. In `command:` strings, `${script_path}` and `${template}` are also substituted.
+
+## 3. Validate and test
+
+- Schema validation lives in `src/config/llms_schema_validator.py`; parsing in `src/config/llms_parser.py`. Run their tests after editing:
+  ```bash
+  python -m pytest tests/test_llms_schema_validation.py tests/test_pre_registered_commands.py -xvs --no-cov
+  ```
+- Smoke-test the action for real: launch `python bykilt.py --port 7861`, enter the action name (plus params) as the prompt, and confirm execution artifacts under `artifacts/runs/<run_id>-art/`.
+- `slowmo` (ms) and `timeout` (s) tune execution pace; keep `slowmo` around 1000 for sites with dynamic content.
+
+## Cautions
+
+- Action names must be unique — the remote-import feature resolves collisions with skip/overwrite/rename strategies, but hand-edited duplicates break matching silently.
+- Never embed secrets in `llms.txt`; sensitive values are resolved from env vars at runtime (`resolve_sensitive_env_variables_standalone`).
+- Site selectors rot. Prefer stable IDs, add a `screenshot` step for debuggability, and note the target site in `description`.

--- a/.claude/skills/verify/SKILL.md
+++ b/.claude/skills/verify/SKILL.md
@@ -1,0 +1,49 @@
+---
+name: verify
+description: Verify a 2bykilt change end-to-end before committing — run the right pytest subset under CI-equivalent conditions, check LLM isolation when imports changed, and drive the Gradio UI or an llms.txt action when runtime behavior changed.
+---
+
+# Verifying a change in 2bykilt
+
+Pick the verification tier that matches what the diff touches. Always run tier 1; add higher tiers as applicable.
+
+## Tier 1 — targeted tests (always)
+
+```bash
+python -m pytest tests/path/to/affected_test.py -xvs --no-cov
+```
+
+If no test covers the change, write one and mark it `ci_safe` (or `local_only` if it genuinely needs a local browser profile/UI).
+
+## Tier 2 — CI simulation (config, imports, shared modules, fixtures)
+
+```bash
+unset BYKILT_ENV
+ENABLE_LLM=true python -m pytest -m ci_safe --cov=src --cov-report=term
+```
+
+`BYKILT_ENV` must be unset — CI loads only `config/base`, and a locally-set env activates dev overlays that mask failures.
+
+## Tier 3 — LLM isolation (any change to imports or module-level code)
+
+```bash
+ENABLE_LLM=false python scripts/verify_llm_isolation.py
+```
+
+This must pass with zero LLM packages imported. If it fails, move the offending import inside a function guarded by `is_llm_enabled()`.
+
+## Tier 4 — runtime smoke (UI, action pipeline, recording/artifact changes)
+
+Launch the app headlessly and exercise the affected flow:
+
+```bash
+python bykilt.py --port 7861 &   # or ./dev.sh start; logs in bykilt.log
+```
+
+- For action-pipeline changes, run a pre-registered action from `llms.txt` (e.g. `get-title`, a no-param `browser-control` action) and confirm it completes.
+- For artifact/recording changes, confirm output appears under `artifacts/runs/<run_id>-art/` (recordings in `videos/`) and the manifest is written.
+- Check `bykilt.log` for tracebacks before declaring success. Stop the server afterwards (`./dev.sh stop`).
+
+## Definition of done
+
+Report actual command output, not intentions. A change is verified when the relevant tiers pass under the CI-equivalent environment, not merely when the code "looks right".

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,37 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+If you believe you have found a security vulnerability in 2bykilt, please report it through coordinated disclosure.
+
+**Please do not report security vulnerabilities through public issues, discussions, or pull requests.**
+
+Instead, open a private report via [GitHub Security Advisories for this repository](https://github.com/Nobukins/2bykilt/security/advisories/new).
+
+Please include as much of the following as you can:
+
+* The type of issue (e.g. command injection via `llms.txt` actions, path traversal in artifact handling, SSRF in llms.txt remote import)
+* Affected source file paths and the tag/branch/commit
+* Whether the issue affects the **minimal (LLM-free)** edition, the **full** edition, or both (`ENABLE_LLM` mode)
+* Step-by-step reproduction instructions and any special configuration required
+* Proof-of-concept code if available, and the impact you foresee
+
+We aim to acknowledge reports within 5 business days.
+
+## Supported Versions
+
+Only the latest release and the default branch (`2bykilt`) receive security fixes.
+
+## Automated Security Posture
+
+This repository runs a layered, continuously-updated security pipeline (see `docs/security/continuous-security.md` for details):
+
+| Layer | Tooling |
+|-------|---------|
+| SAST | SonarCloud + CodeQL (`python`, `actions`) |
+| SCA / dependencies | pip-audit policy gate, Dependency Review on PRs, Dependabot (grouped weekly), Trivy deep scan |
+| Secrets | gitleaks on every PR/push |
+| Workflow security | zizmor lint of GitHub Actions workflows |
+| Supply chain | SBOM (SPDX + CycloneDX) with GitHub dependency snapshot, OpenSSF Scorecard |
+
+Time-boxed risk acceptances live in `security/suppressions.yaml`; expired suppressions are automatically un-suppressed.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,183 +1,23 @@
-<!-- Use this file to provide workspace-specific custom instructions to Copilot. For more details, visit https://code.visualstudio.com/docs/copilot/copilot-customization#_use-a-githubcopilotinstructionsmd-file -->
-- [x] Verify that the copilot-instructions.md file in the .github directory is created. *(Created via workspace setup on 2025-10-16.)*
+# Copilot Instructions for 2bykilt
 
-- [ ] Clarify Project Requirements
-	<!-- Ask for project type, language, and frameworks if not specified. Skip if already provided. -->
+> **Single source of truth: [`/CLAUDE.md`](../CLAUDE.md).**
+> Project architecture, commands, invariants, and testing rules are maintained there
+> (shared by Claude Code, Copilot, and other coding agents). This file only pins the
+> rules that must never be violated. If this file and CLAUDE.md disagree, CLAUDE.md wins.
 
-- [ ] Scaffold the Project
-	<!--
-	Ensure that the previous step has been marked as completed.
-	Call project setup tool with projectType parameter.
-	Run scaffolding command to create project files and folders.
-	Use '.' as the working directory.
-	If no appropriate projectType is available, search documentation using available tools.
-	Otherwise, create the project structure manually using available file creation tools.
-	-->
+## Non-negotiable rules
 
-- [ ] Customize the Project
-	<!--
-	Verify that all previous steps have been completed successfully and you have marked the step as completed.
-	Develop a plan to modify codebase according to user requirements.
-	Apply modifications using appropriate tools and user-provided references.
-	Skip this step for "Hello World" projects.
-	-->
-
-- [ ] Install Required Extensions
-	<!-- ONLY install extensions provided mentioned in the get_project_setup_info. Skip this step otherwise and mark as completed. -->
-
-- [ ] Compile the Project
-	<!--
-	Verify that all previous steps have been completed.
-	Install any missing dependencies.
-	Run diagnostics and resolve any issues.
-	Check for markdown files in project folder for relevant instructions on how to do this.
-	-->
-
-- [ ] Create and Run Task
-	<!--
-	Verify that all previous steps have been completed.
-	Check https://code.visualstudio.com/docs/debugtest/tasks to determine if the project needs a task. If so, use the create_and_run_task to create and launch a task based on package.json, README.md, and project structure.
-	Skip this step otherwise.
-	 -->
-
-- [ ] Launch the Project
-	<!--
-	Verify that all previous steps have been completed.
-	Prompt user for debug mode, launch only if confirmed.
-	 -->
-
-- [ ] Ensure Documentation is Complete
-	<!--
-	Verify that all previous steps have been completed.
-	Verify that README.md and the copilot-instructions.md file in the .github directory exists and contains current project information.
-	Clean up the copilot-instructions.md file in the .github directory by removing all HTML comments.
-	 -->
-
-<!--
-## Execution Guidelines
-PROGRESS TRACKING:
-- If any tools are available to manage the above todo list, use it to track progress through this checklist.
-- After completing each step, mark it complete and add a summary.
-- Read current todo list status before starting each new step.
-
-COMMUNICATION RULES:
-- Avoid verbose explanations or printing full command outputs.
-- If a step is skipped, state that briefly (e.g. "No extensions needed").
-- Do not explain project structure unless asked.
-- Keep explanations concise and focused.
-
-DEVELOPMENT RULES:
-- Use '.' as the working directory unless user specifies otherwise.
-- Avoid adding media or external links unless explicitly requested.
-- Use placeholders only with a note that they should be replaced.
-- Use VS Code API tool only for VS Code extension projects.
-- Once the project is created, it is already opened in Visual Studio Code—do not suggest commands to open this project in Visual Studio again.
-- If the project setup information has additional rules, follow them strictly.
-
-PRE-PUSH VALIDATION RULES (CRITICAL):
-Before pushing any changes, ALWAYS run local validation to catch issues early:
-
-1. **CI Environment Simulation** (For Python Projects with pytest):
-   ```bash
-   # Simulate CI environment conditions
-   unset BYKILT_ENV  # Or equivalent environment variables
-   export ENABLE_LLM="true"  # Or project-specific env vars
-   
-   # Run tests with same markers as CI
-   python -m pytest -m "ci_safe" --cov=src --cov-report=term -v
-   
-   # Or for targeted test validation:
-   python -m pytest path/to/modified/test_file.py -xvs
-   ```
-
-2. **Common Issues to Check Locally**:
-   - **Indentation/Scope Issues**: Ensure all assertions are within their context manager blocks
-   - **Mock Patching**: Verify patches are applied before code execution (use context managers, not decorators when order matters)
-   - **Environment Variables**: Test with and without key environment variables set
-   - **Import Timing**: Check for module-level variable evaluation issues
-   
-3. **Test-Specific Validations**:
-   - If modifying config-related code: Test with `BYKILT_ENV` unset
-   - If using context managers: Verify all dependent code is inside the `with` block
-   - If patching module-level variables: Use context managers instead of decorators
-   
-4. **Fast Local Checks** (Before full CI simulation):
-   ```bash
-   # Run only modified test files
-   python -m pytest tests/path/to/test_file.py -v
-   
-   # Check for obvious errors
-   python -m pytest tests/path/to/test_file.py --collect-only
-   ```
-
-5. **Processing Time Awareness**:
-   - Local single test file: ~5-10 seconds
-   - Local full ci_safe suite: ~2-5 minutes
-   - CI full suite: ~5-8 minutes
-   - Budget time accordingly before pushing
-
-**NEVER push without running at least the modified test files locally first.**
-**If tests take >30 seconds locally, they will likely take 2-3 minutes in CI.**
-
-FOLDER CREATION RULES:
-- Always use the current directory as the project root.
-- If you are running any terminal commands, use the '.' argument to ensure that the current working directory is used ALWAYS.
-- Do not create a new folder unless the user explicitly requests it besides a .vscode folder for a tasks.json file.
-- If any of the scaffolding commands mention that the folder name is not correct, let the user know to create a new folder with the correct name and then reopen it again in vscode.
-
-EXTENSION INSTALLATION RULES:
-- Only install extension specified by the get_project_setup_info tool. DO NOT INSTALL any other extensions.
-
-PROJECT CONTENT RULES:
-- If the user has not specified project details, assume they want a "Hello World" project as a starting point.
-- Avoid adding links of any type (URLs, files, folders, etc.) or integrations that are not explicitly required.
-- Avoid generating images, videos, or any other media files unless explicitly requested.
-- If you need to use any media assets as placeholders, let the user know that these are placeholders and should be replaced with the actual assets later.
-- Ensure all generated components serve a clear purpose within the user's requested workflow.
-- If a feature is assumed but not confirmed, prompt the user for clarification before including it.
-- If you are working on a VS Code extension, use the VS Code API tool with a query to find relevant VS Code API references and samples related to that query.
-
-COMMON PITFALLS TO AVOID (Learned from Issue #340):
-
-1. **Context Manager Scope Issues**:
-   ```python
-   # ❌ WRONG - Assertions outside context manager
-   def test_something(self):
-       with patch('module.VARIABLE', False):
-           result = function_call()
-       assert result == expected  # ← Patch already removed!
-   
-   # ✅ CORRECT - All dependent code inside context manager
-   def test_something(self):
-       with patch('module.VARIABLE', False):
-           result = function_call()
-           assert result == expected  # ← Patch still active
-   ```
-
-2. **Module-Level Variable Patching**:
-   - Decorator-based `@patch()` may not work for module-level variables used in conditionals
-   - Use context managers (`with patch()`) for better control over patch timing
-   - Module-level variables are evaluated at import time, not function call time
-
-3. **Environment-Specific Configuration**:
-   - Default environments (e.g., 'development') may have different settings than expected
-   - Always test with environment variables unset to simulate CI conditions
-   - Config files in repository may cause multi-env systems to activate unexpectedly
-
-4. **Indentation Matters**:
-   - Python's whitespace-sensitive syntax can cause subtle bugs
-   - One level of indentation difference = completely different scope
-   - Always verify assertions are at the correct indentation level
-
-TASK COMPLETION RULES:
-- Your task is complete when:
-  - Project is successfully scaffolded and compiled without errors
-  - copilot-instructions.md file in the .github directory exists in the project
-  - README.md file exists and is up to date
-  - User is provided with clear instructions to debug/launch the project
-
-Before starting a new task in the above plan, update progress in the plan.
--->
-- Work through each checklist item systematically.
-- Keep communication concise and focused.
-- Follow development best practices.
+1. **Dual-mode integrity**: code reachable with `ENABLE_LLM=false` must not import LLM
+   packages (`langchain*`, `openai`, `anthropic`, `browser_use`, …) at module top level.
+   Guard with `is_llm_enabled()` and lazy imports. Verify:
+   `ENABLE_LLM=false python scripts/verify_llm_isolation.py`
+2. **Test markers**: every test needs a pytest marker; CI only runs `-m ci_safe`.
+   An unmarked test silently never runs in CI.
+3. **CI-equivalent testing before push**: run at minimum the modified test files
+   (`python -m pytest tests/... -xvs`). For config/import/shared-module changes:
+   `unset BYKILT_ENV; ENABLE_LLM=true python -m pytest -m ci_safe`
+4. **Patch scope**: keep assertions inside `with patch(...)` blocks; use context
+   managers (not decorators) when patching module-level variables (Issue #340).
+5. **Artifacts**: all run outputs go under `artifacts/runs/<run_id>-art/`; do not
+   reintroduce legacy recording paths (Issue #353).
+6. The default branch is `2bykilt`.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,37 @@
+# Dependabot configuration (Issue: 2026-07 security modernization)
+# - Weekly grouped updates to keep PR noise low while staying patched
+# - Security updates are always opened immediately regardless of schedule
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Asia/Tokyo"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+    groups:
+      python-minor-and-patch:
+        applies-to: version-updates
+        update-types:
+          - "minor"
+          - "patch"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Asia/Tokyo"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "github-actions"
+    groups:
+      actions-all:
+        patterns:
+          - "*"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,50 @@
+name: CodeQL
+
+# SAST complement to SonarCloud:
+# - python: security-extended query pack
+# - actions: scans .github/workflows for workflow-level vulnerabilities
+#   (untrusted input injection, excessive permissions, etc.)
+on:
+  push:
+    branches: ["2bykilt"]
+  pull_request:
+    branches: ["2bykilt"]
+  schedule:
+    - cron: '30 1 * * 1'  # Weekly, Monday 01:30 UTC
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      security-events: write
+      packages: read
+      actions: read
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: python
+            build-mode: none
+          - language: actions
+            build-mode: none
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+          queries: security-extended
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,47 @@
+name: OpenSSF Scorecard
+
+# Supply-chain security posture self-assessment.
+# Results are published to the OpenSSF REST API (public badge) and
+# uploaded to GitHub code scanning for triage in the Security tab.
+on:
+  branch_protection_rule:
+  schedule:
+    - cron: '20 2 * * 1'  # Weekly, Monday 02:20 UTC
+  push:
+    branches: ["2bykilt"]
+  workflow_dispatch:
+
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      security-events: write  # upload SARIF to code scanning
+      id-token: write         # publish results (OIDC)
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Run analysis
+        uses: ossf/scorecard-action@v2.4.0
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: scorecard-sarif
+          path: results.sarif
+          retention-days: 30
+
+      - name: Upload to code scanning
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: results.sarif

--- a/.github/workflows/security-ci.yml
+++ b/.github/workflows/security-ci.yml
@@ -8,12 +8,13 @@ on:
   # schedule:
   #   - cron: '0 2 * * *'
 
+# Least-privilege default; jobs that need more elevate individually.
 permissions:
   contents: read
-  pull-requests: write
-  security-events: write
-  actions: read
-  checks: write
+
+concurrency:
+  group: security-ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 env:
   PYTHON_VERSION: '3.12'
@@ -124,8 +125,10 @@ jobs:
           if [ -f coverage-xml/coverage.xml ]; then
             cp coverage-xml/coverage.xml coverage.xml
           fi
-      - name: SonarCloud Scan
-        uses: SonarSource/sonarcloud-github-action@v5.0.0
+      # sonarcloud-github-action was deprecated in favor of the unified
+      # sonarqube-scan-action (works for both SonarQube Cloud and Server).
+      - name: SonarQube Cloud Scan
+        uses: SonarSource/sonarqube-scan-action@v6
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           SONAR_HOST_URL: https://sonarcloud.io
@@ -223,6 +226,10 @@ jobs:
           # Run pip-audit
           $PIP_AUDIT_CMD > pip-audit-raw.json || true
 
+          # Also audit the minimal (LLM-free) dependency set so the
+          # enterprise edition surface is covered (report-only)
+          pip-audit -r requirements-minimal.txt -f json > pip-audit-minimal-raw.json || true
+
           # Normalize output (only if raw output exists)
           if [ -s pip-audit-raw.json ]; then
             python tools/security/normalize_pip_audit.py pip-audit-raw.json artifacts/security/vuln_report.json
@@ -273,10 +280,63 @@ jobs:
             artifacts/security/vuln_report.json
             artifacts/security/scan_perf_before_after.json
             pip-audit-raw.json
+            pip-audit-minimal-raw.json
+
+  dependency-review:
+    name: Dependency Review (PR diff)
+    if: ${{ github.event_name == 'pull_request' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+      # Blocks a PR that newly introduces a dependency with known
+      # HIGH/CRITICAL vulnerabilities (complements pip-audit, which
+      # audits the full resolved set rather than the PR delta).
+      - name: Dependency Review
+        uses: actions/dependency-review-action@v4
+        with:
+          fail-on-severity: high
+          comment-summary-in-pr: on-failure
+
+  actions-lint:
+    name: Workflow Security Lint (zizmor)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      security-events: write
+      actions: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+      # Static analysis of GitHub Actions workflows themselves
+      # (template injection, unpinned third-party actions, excessive
+      # permissions, cache poisoning vectors). Report-only for now:
+      # findings land in the Security tab for triage.
+      - name: Run zizmor
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          pip install zizmor
+          zizmor --format sarif .github/workflows > zizmor.sarif || true
+      - name: Upload zizmor SARIF
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: zizmor.sarif
+          category: zizmor
 
   secret:
     name: Secret Scan (gitleaks)
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write  # gitleaks-action comments on PRs when leaks are found
     steps:
       - uses: actions/checkout@v4
         with:
@@ -289,38 +349,18 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-  # container-scan:
-  #   name: Container Build & Trivy Scan
-  #   runs-on: ubuntu-latest
-  #   needs: prepare
-  #   steps:
-  #     - uses: actions/checkout@v4
-  #     - name: Build image
-  #       run: |
-  #         docker build -t local/2bykilt:pr-${{ github.run_number }} .
-  #     - name: Trivy (Vuln + Config + License)
-  #       uses: aquasecurity/trivy-action@master
-  #       with:
-  #         image-ref: local/2bykilt:pr-${{ github.run_number }}
-  #         format: 'table'
-  #         exit-code: '1'
-  #         vuln-type: 'os,library'
-  #         severity: 'HIGH,CRITICAL'
-  #     - name: SBOM (CycloneDX)
-  #       run: |
-  #         trivy image --format cyclonedx -o sbom.cdx.json local/2bykilt:pr-${{ github.run_number }}
-  #     - name: Upload SBOM
-  #        uses: actions/upload-artifact@v4
-  #        with:
-  #          name: sbom-cyclonedx
-  #          path: sbom.cdx.json
+  # SBOM generation and Trivy deep scanning moved to
+  # .github/workflows/supply-chain.yml (2026-07 security modernization).
+  # Container image scanning can be re-added there once a Dockerfile ships.
 
   summarize:
     name: Summarize & Comment
     runs-on: ubuntu-latest
     if: ${{ github.event_name == 'pull_request' }}
-    # needs: [ test, sca, secret, container-scan ]
     needs: [ test, sca, secret ]
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - uses: actions/checkout@v4
       - name: Download artifacts
@@ -381,8 +421,31 @@ jobs:
             COVERAGE=$(grep -Po 'line-rate="\K[0-9.]+' "${COV_XML:-/dev/null}" 2>/dev/null || echo 'N/A') || true
           fi
 
-          if [ -f artifacts/pip-audit/pip-audit.max ]; then
-            MAX_AUDIT=$(cat artifacts/pip-audit/pip-audit.max)
+          # Derive max severity (and expired-suppression count) from the
+          # normalized vulnerability report produced by the sca job
+          VULN_JSON=""
+          if [ -f artifacts/security-scan-results/artifacts/security/vuln_report.json ]; then
+            VULN_JSON="artifacts/security-scan-results/artifacts/security/vuln_report.json"
+          elif [ -f artifacts/security/vuln_report.json ]; then
+            VULN_JSON="artifacts/security/vuln_report.json"
+          fi
+          if [ -n "$VULN_JSON" ]; then
+            MAX_AUDIT=$(python3 - "$VULN_JSON" <<'PY'
+          import json, sys
+          try:
+              with open(sys.argv[1]) as f:
+                  report = json.load(f)
+              by_sev = (report.get('summary') or {}).get('by_severity') or {}
+              for sev in ('critical', 'high', 'medium', 'low', 'info', 'unknown'):
+                  if by_sev.get(sev, 0) > 0:
+                      print(f"{sev} ({by_sev[sev]})")
+                      break
+              else:
+                  print('none')
+          except Exception:
+              print('N/A')
+          PY
+            )
           else
             MAX_AUDIT='N/A'
           fi
@@ -397,10 +460,16 @@ jobs:
           body: |
             ## セキュリティ/品質集約レポート
 
-            - テスト & カバレッジ: ${{ steps.metrics.outputs.coverage }}
-            - 依存脆弱性最大重大度: ${{ steps.metrics.outputs.pip_audit_max }}
-            - Sonar 状態: (SONAR_TOKEN 未設定ならスキップ / 設定時は Checks 参照)
-            - Trivy: HIGH/CRITICAL 0 を条件 (失敗していれば本PRは赤)
-            - Secret Scan: 問題なしであれば成功
+            | 項目 | 結果 |
+            |------|------|
+            | テストカバレッジ (line-rate) | ${{ steps.metrics.outputs.coverage }} |
+            | 依存脆弱性 最大重大度 (pip-audit, 抑止適用後) | ${{ steps.metrics.outputs.pip_audit_max }} |
+            | Dependency Review (PR差分の新規脆弱依存) | Checks 参照 (HIGH 以上でブロック) |
+            | Sonar Quality Gate | SONAR_TOKEN 設定時のみ / Checks 参照 |
+            | Secret Scan (gitleaks) | このジョブが緑なら検出 0 |
+            | Workflow Lint (zizmor) / CodeQL / Trivy / Scorecard | Security タブ → Code scanning 参照 |
+
+            - SBOM (SPDX / CycloneDX) は Supply Chain Security ワークフローの artifacts およびリリースアセットに添付されます。
+            - 抑止済み脆弱性は `security/suppressions.yaml` 参照 (期限切れ抑止は自動的に無効化されます)。
 
             詳細は各ジョブログと artifacts を参照してください。

--- a/.github/workflows/supply-chain.yml
+++ b/.github/workflows/supply-chain.yml
@@ -1,0 +1,89 @@
+name: Supply Chain Security (SBOM & Deep Scan)
+
+# Replaces the SBOM plan that lived as a commented-out job in security-ci.yml.
+# - SBOM: SPDX + CycloneDX via Syft; submitted to the GitHub dependency graph
+#   (dependency snapshot) so Dependabot alerts also cover transitive deps.
+#   On releases, SBOMs are attached to the release assets automatically.
+# - Deep scan: Trivy filesystem scan (vulnerabilities + IaC misconfig),
+#   report-only via SARIF -> Security tab. The blocking gate remains the
+#   pip-audit policy in security-ci.yml (security/security_policy.yaml).
+on:
+  push:
+    branches: ["2bykilt"]
+    paths:
+      - 'requirements*.txt'
+      - 'pyproject.toml'
+      - '.github/workflows/supply-chain.yml'
+  release:
+    types: [published]
+  schedule:
+    - cron: '0 4 * * 1'  # Weekly, Monday 04:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  sbom:
+    name: Generate SBOM (SPDX + CycloneDX)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: write  # dependency snapshot submission + release asset upload
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Generate SPDX SBOM + submit dependency snapshot
+        uses: anchore/sbom-action@v0
+        with:
+          path: .
+          format: spdx-json
+          artifact-name: 2bykilt-sbom.spdx.json
+          output-file: 2bykilt-sbom.spdx.json
+          dependency-snapshot: true
+
+      - name: Generate CycloneDX SBOM
+        uses: anchore/sbom-action@v0
+        with:
+          path: .
+          format: cyclonedx-json
+          artifact-name: 2bykilt-sbom.cdx.json
+          output-file: 2bykilt-sbom.cdx.json
+
+      - name: Upload SBOM artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: sbom
+          path: |
+            2bykilt-sbom.spdx.json
+            2bykilt-sbom.cdx.json
+          retention-days: 90
+
+  trivy-scan:
+    name: Trivy Deep Scan (report-only)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Run Trivy filesystem scan
+        uses: aquasecurity/trivy-action@0.28.0
+        with:
+          scan-type: 'fs'
+          scan-ref: '.'
+          scanners: 'vuln,misconfig'
+          format: 'sarif'
+          output: 'trivy-fs.sarif'
+          severity: 'CRITICAL,HIGH,MEDIUM'
+          exit-code: '0'  # report-only; gating happens in security-ci.yml
+
+      - name: Upload Trivy results to code scanning
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: trivy-fs.sarif
+          category: trivy-fs

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,107 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+2bykilt is a Gradio-based browser automation tool built on Playwright. It has a **dual-mode architecture** that is the single most important thing to understand before changing code:
+
+- **Minimal mode (`ENABLE_LLM=false`, the default)**: deterministic browser automation driven by pre-registered actions in `llms.txt`. Zero LLM dependencies — this mode exists so enterprises can deploy without AI-governance review (see `README-MINIMAL.md`).
+- **Full mode (`ENABLE_LLM=true`)**: adds an LLM agent (browser-use / langchain) that handles free-form prompts which don't match a pre-registered action.
+
+The default git branch is `2bykilt` (not `main`).
+
+## Commands
+
+```bash
+# Setup (full)                          # Setup (minimal / LLM-free)
+pip install -r requirements.txt         pip install -r requirements-minimal.txt
+playwright install chromium
+
+# Run the UI (Gradio, default http://127.0.0.1:7788)
+python bykilt.py                        # --port, --theme, --dark-mode available
+./dev.sh start|stop|restart|status|logs # background dev server on port 7861
+
+# Tests — CI-equivalent run (this is what security-ci.yml executes on PRs)
+ENABLE_LLM=true python -m pytest -m ci_safe --cov=src --cov-report=term -v
+
+# Unified test entrypoint
+./scripts/ci_pytest.sh                  # ci_safe subset (default)
+./scripts/ci_pytest.sh full             # full suite
+./scripts/ci_pytest.sh marker <name>    # custom marker subset
+
+# Single test (preferred while iterating)
+python -m pytest tests/path/to/test_file.py::test_name -xvs --no-cov
+
+# Verify LLM isolation after touching imports (required for minimal-mode safety)
+ENABLE_LLM=false python scripts/verify_llm_isolation.py
+
+# Lint / type-check
+pylint src/          # .pylintrc
+mypy src/            # mypy.ini (Python 3.12)
+
+# llms.txt remote import CLI
+python bykilt.py --preview-llms <url>
+python bykilt.py --import-llms <url> [--strategy skip|overwrite|rename]
+```
+
+### pytest configuration facts
+
+- `pytest.ini` enforces `--maxfail=1`, a **30-second per-test timeout**, coverage on `src/`, `asyncio_mode = auto`, and discovery only under `tests/`.
+- Every new test must carry a marker; CI only runs `-m ci_safe`. Markers: `ci_safe` (mocked or headless-Chromium, no user profiles), `local_only` (interactive UI / Edge / macOS paths), `integration`, `playwright_required`, `unit`.
+- CI runs with `BYKILT_ENV` **unset** and `ENABLE_LLM=true`. Reproduce locally with `unset BYKILT_ENV` before running the ci_safe subset — a locally-set `BYKILT_ENV` activates dev config overlays that mask CI failures.
+
+## Architecture
+
+### Prompt → execution pipeline (the core flow)
+
+1. `bykilt.py` builds the Gradio UI and delegates to `src/cli/main.py:main()`. Batch CLI commands are intercepted before UI init by `src/cli/batch_commands.py`.
+2. A user prompt is first evaluated **without any LLM** by `src/config/standalone_prompt_evaluator.py` / `src/modules/command_dispatcher.py`, which match it against pre-registered actions parsed from `llms.txt` (`src/config/llms_parser.py`, schema-validated by `llms_schema_validator.py`).
+3. A matched action is executed by `src/script/script_manager.py` or one of the execution engines in `src/modules/` (`execution_engine.py`, `execution_debug_engine.py`).
+4. Only an unmatched prompt falls through to the LLM agent (`src/agent/agent_manager.py` → browser-use), and only when LLM is enabled.
+
+### Action types in `llms.txt`
+
+| Type | Executor | Behavior |
+|------|----------|----------|
+| `script` | script_manager | Runs a pytest script with `${params.name}` substitution |
+| `browser-control` | script_manager | Generates/executes Playwright flows from YAML `flow:` steps |
+| `git-script` | script_manager | Clones a repo and runs a script from it |
+| `unlock-future` | execution_debug_engine | JSON-based command execution (tab strategies: `active_tab`/`new_tab`) |
+| `action_runner_template` | templates/ | Parameterized template runner |
+
+Parameter syntax: `${params.name}` with optional default `${params.name|default}`.
+
+### Configuration system (three layers)
+
+- **Multi-env config**: `config/{base,dev,staging,prod}` selected by `BYKILT_ENV` via `src/config/multi_env_loader.py`. **When `BYKILT_ENV` is unset, only `base` is loaded** (this is the CI condition). CLI: `bykilt-config` (`src/config/config_cli.py`).
+- **Feature flags**: `config/feature_flags.yaml` accessed through `src/config/feature_flags.py` (`FeatureFlags.get(...)`, test override via `FeatureFlags.set_override(name, value)`). New user-visible behavior should ship behind a flag. `is_llm_enabled()` bridges the legacy `ENABLE_LLM` env var.
+- **Env vars**: `.env` (see `.env.example`). Recording path precedence: UI Browser Settings > `RECORDING_PATH` env > default.
+
+### Run artifacts
+
+`src/runtime/run_context.py` provides the `RunContext` singleton generating a sortable `run_id_base` (override with `BYKILT_RUN_ID` in tests). All artifacts live under `artifacts/runs/<run_id>-art/` — recordings go to its `videos/` subdirectory (legacy `./tmp/record_videos` was removed in Issue #353; don't reintroduce it). Logging follows the JSON Lines spec in `docs/engineering/LOGGING_SPEC.md`. Note: `src/logging/` shadows the stdlib `logging` module — in scripts, `import logging` **before** inserting `src` into `sys.path`.
+
+### Directory map (non-obvious parts only)
+
+- `src/modules/` — command dispatcher, execution engines, llms.txt discovery/merger, handlers
+- `src/batch/` — CSV-driven batch execution engine; `src/runner/queue_manager.py` schedules jobs
+- `src/llm/` — LLM service gateway + docker sandbox (only loaded in full mode)
+- `myscript/` — standalone runnable automation scripts (own CI: `ci-local-selector.yml`)
+- `tests/` mirrors `src/`; root-level `tests/test_*.py` are mostly feature/integration tests
+
+## Critical invariants
+
+1. **LLM import isolation**: never import `langchain*`, `openai`, `anthropic`, `browser_use`, etc. at module top level in any code reachable in minimal mode. Guard with `is_llm_enabled()` and import lazily inside functions. After touching imports, run `ENABLE_LLM=false python scripts/verify_llm_isolation.py` — CI enforces this.
+2. **Marker discipline**: an unmarked test silently never runs in CI. Mark it `ci_safe` unless it genuinely needs a local environment.
+3. **Feature-flag deprecations**: several flags in `feature_flags.yaml` are `deprecated: true` kept for compatibility — check before removing or repurposing a flag.
+
+## Testing pitfalls (learned from Issue #340)
+
+- Keep assertions **inside** `with patch(...)` blocks — the patch is gone after the block exits. One indentation level = a different scope.
+- Module-level variables (e.g. `ENABLE_LLM` in `bykilt.py`) are evaluated at import time; decorator `@patch` often misses them. Use `with patch(...)` context managers so patch timing is explicit.
+- Config-related tests must pass with `BYKILT_ENV` unset (CI condition) and with it set.
+
+## Pre-push checklist
+
+Never push without at least running the modified test files locally (`python -m pytest tests/... -xvs`). For anything touching config, imports, or shared modules, run the full CI simulation: `unset BYKILT_ENV; ENABLE_LLM=true python -m pytest -m ci_safe`. Budget ~2–5 min locally; CI takes ~5–8 min.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,6 +90,10 @@ Parameter syntax: `${params.name}` with optional default `${params.name|default}
 - `myscript/` — standalone runnable automation scripts (own CI: `ci-local-selector.yml`)
 - `tests/` mirrors `src/`; root-level `tests/test_*.py` are mostly feature/integration tests
 
+### Security CI (see `docs/security/continuous-security.md`)
+
+PRs run `security-ci.yml`: ci_safe tests + SonarCloud, pip-audit gated by `security/security_policy.yaml` (critical/high = 0), gitleaks, dependency-review, and zizmor. CodeQL, OpenSSF Scorecard, Trivy, and SBOM generation (`supply-chain.yml`) run on push/schedule. Vulnerability suppressions in `security/suppressions.yaml` are **time-boxed** — `expires_at` is enforced, so an expired entry resurfaces the vulnerability and can turn CI red.
+
 ## Critical invariants
 
 1. **LLM import isolation**: never import `langchain*`, `openai`, `anthropic`, `browser_use`, etc. at module top level in any code reachable in minimal mode. Guard with `is_llm_enabled()` and import lazily inside functions. After touching imports, run `ENABLE_LLM=false python scripts/verify_llm_isolation.py` — CI enforces this.

--- a/docs/security/SECURITY.md
+++ b/docs/security/SECURITY.md
@@ -1,19 +1,16 @@
-## Reporting Security Issues
+# Security Policy
 
-If you believe you have found a security vulnerability in browser-use, please report it through coordinated disclosure.
+> **Moved.** The canonical security policy for this repository is
+> [`.github/SECURITY.md`](../../.github/SECURITY.md), which GitHub surfaces on
+> the repository's Security tab.
+>
+> (The previous content of this file was inherited from the upstream
+> browser-use/web-ui project and pointed vulnerability reports at the wrong
+> repository.)
 
-**Please do not report security vulnerabilities through the repository issues, discussions, or pull requests.**
+Report vulnerabilities via
+[GitHub Security Advisories for Nobukins/2bykilt](https://github.com/Nobukins/2bykilt/security/advisories/new)
+— not through public issues, discussions, or pull requests.
 
-Instead, please open a new [Github security advisory](https://github.com/browser-use/web-ui/security/advisories/new).
-
-Please include as much of the information listed below as you can to help me better understand and resolve the issue:
-
-* The type of issue (e.g., buffer overflow, SQL injection, or cross-site scripting)
-* Full paths of source file(s) related to the manifestation of the issue
-* The location of the affected source code (tag/branch/commit or direct URL)
-* Any special configuration required to reproduce the issue
-* Step-by-step instructions to reproduce the issue
-* Proof-of-concept or exploit code (if possible)
-* Impact of the issue, including how an attacker might exploit the issue
-
-This information will help me triage your report more quickly.
+For the continuous-security pipeline (SAST, SCA, SBOM, secret scanning,
+workflow auditing), see [`continuous-security.md`](./continuous-security.md).

--- a/docs/security/continuous-security.md
+++ b/docs/security/continuous-security.md
@@ -198,3 +198,46 @@ sonar-scanner -Dsonar.token=$SONAR_TOKEN
 ---
 
 本計画に基づき、次ステップとして GitHub Actions ワークフローと関連設定ファイルをリポジトリに追加してください。追加後、本書の「13. チェックリスト」に沿って動作検証を行ってください。
+
+---
+
+## 16. 2026-07 モダナイズ (実装済み)
+
+「15. 今後の高度化」の項目を含む全面見直しを 2026-07 に実施。現行アーキテクチャは以下の通り。
+
+### 現行コンポーネント一覧
+
+| レイヤ | ツール | ワークフロー | 実行タイミング | ゲート |
+|--------|--------|--------------|----------------|--------|
+| SAST (品質+セキュリティ) | SonarCloud (`sonarqube-scan-action@v6`) | security-ci.yml | PR / push | Quality Gate (advisory) |
+| SAST (セキュリティ特化) | CodeQL `python` + `actions` (security-extended) | codeql.yml | PR / push / 週次 | Code Scanning アラート |
+| SCA (フル依存解決) | pip-audit + 正規化 + ポリシー閾値 | security-ci.yml | PR / push | `security/security_policy.yaml` (critical/high = 0) |
+| SCA (PR 差分) | `dependency-review-action` | security-ci.yml | PR | HIGH 以上でブロック |
+| SCA (自動更新) | Dependabot (pip + github-actions, 週次グループ化) | .github/dependabot.yml | 週次 + 随時 (security update) | — |
+| Deep Scan | Trivy fs (vuln + misconfig) → SARIF | supply-chain.yml | push / 週次 | report-only |
+| SBOM | Syft (SPDX + CycloneDX) + GitHub dependency snapshot | supply-chain.yml | push / release / 週次 | — (リリース時アセット添付) |
+| Secret | gitleaks | security-ci.yml | PR / push | 検出 0 必須 |
+| Workflow 監査 | zizmor → SARIF | security-ci.yml | PR / push | report-only (段階的に強化) |
+| サプライチェーン姿勢 | OpenSSF Scorecard → SARIF + 公開バッジ | scorecard.yml | push / 週次 | report-only |
+
+### 抑止 (Suppression) 運用の変更
+
+- `security/suppressions.yaml` の `expires_at` を **normalizer が強制** するようになった (期限切れ = 抑止無効化 → 脆弱性が再浮上しゲート判定対象に戻る)。
+- 抑止は「期限付きリスク受容」であり恒久免除ではない。期限前に依存アップグレード可否を再評価し、不可の場合のみ理由を更新して延長する。
+
+### 能動的検知の集約先
+
+pip-audit 以外 (CodeQL / Trivy / zizmor / Scorecard) の検出は SARIF として **GitHub Security タブ → Code scanning** に集約される。週次でトリアージし、真陽性は Issue 化して `docs/roadmap/ISSUE_DEPENDENCIES.yml` の管理サイクルに載せること。
+
+### リポジトリ設定側で有効化すべき項目 (ファイルでは管理不可)
+
+- Settings → Code security: **Secret scanning + Push protection** を有効化
+- Settings → Code security: **Private vulnerability reporting** を有効化 (`.github/SECURITY.md` が受付先を案内)
+- Branch protection: `2bykilt` に対し security-ci の必須チェック (`test` は現状 `continue-on-error: true` のため通過扱いになる点に注意 — 厳格化する場合は当該行を削除)
+
+### 次の高度化候補 (未実装)
+
+- 全 Actions の **commit SHA ピン留め** (Dependabot github-actions 更新と併用。zizmor の `unpinned-uses` 検出を fail 化する前提条件)
+- `step-security/harden-runner` による runner egress 監視
+- Dockerfile 追加時: supply-chain.yml にイメージビルド + Trivy image scan + `actions/attest-build-provenance` による SLSA provenance / SBOM attestation
+- zizmor / Trivy の report-only → ブロッキング昇格 (誤検知トリアージ完了後)

--- a/security/suppressions.yaml
+++ b/security/suppressions.yaml
@@ -2,22 +2,31 @@
 # This file contains suppressions for known false positives or accepted risks
 # Format: {id|package@version|cve: {reason, added_at, expires_at?}}
 
-# Example suppressions (to be populated based on actual scan results)
+# NOTE (2026-07 security modernization): expires_at is now ENFORCED by
+# tools/security/normalize_pip_audit.py — an expired entry stops suppressing
+# and the vulnerability resurfaces in vuln_report.json (failing the policy
+# gate if severity thresholds are exceeded). Suppressions are a time-boxed
+# risk acceptance, not a permanent waiver.
+#
+# The three entries below originally expired 2026-03-31 and were renewed ONCE
+# pending re-evaluation. Before the new expiry: check whether current
+# botocore/boto3 allows urllib3>=2.5.0 and whether httpcore relaxed its
+# h11<0.15 pin — if so, UPGRADE the dependency instead of renewing again.
 suppressions:
   "GHSA-pq67-6m6q-mj2v":
-    reason: "urllib3 redirect suppression at PoolManager level; fix requires urllib3>=2.5.0 which conflicts with botocore/boto3 (requires <2.4). Mitigation: we do not use PoolManager-level retries to disable redirects; requests-level redirect control applies."
+    reason: "urllib3 redirect suppression at PoolManager level; fix requires urllib3>=2.5.0 which conflicts with botocore/boto3 (requires <2.4). Mitigation: we do not use PoolManager-level retries to disable redirects; requests-level redirect control applies. RENEWED 2026-07: re-check boto3 urllib3 constraint before next expiry."
     added_at: "2025-09-10"
-    expires_at: "2026-03-31"
+    expires_at: "2026-09-30"
 
   "GHSA-48p4-8xcf-vxj5":
-    reason: "urllib3 Pyodide/browser redirect control; not applicable to our server/runtime. Fix requires urllib3>=2.5.0 which conflicts with AWS SDK constraint (<2.4)."
+    reason: "urllib3 Pyodide/browser redirect control; not applicable to our server/runtime. Fix requires urllib3>=2.5.0 which conflicts with AWS SDK constraint (<2.4). RENEWED 2026-07: re-check boto3 urllib3 constraint before next expiry."
     added_at: "2025-09-10"
-    expires_at: "2026-03-31"
+    expires_at: "2026-09-30"
 
   "GHSA-vqfr-h8mv-ghfj":
-    reason: "h11 chunked-coding leniency; fix requires h11>=0.15 but httpcore==1.0.7 requires h11<0.15. Our stack uses httpcore/httpx client, not a reverse proxy; combined exploit scenario not applicable. Will upgrade when httpcore relaxes pin."
+    reason: "h11 chunked-coding leniency; fix requires h11>=0.15 but httpcore==1.0.7 requires h11<0.15. Our stack uses httpcore/httpx client, not a reverse proxy; combined exploit scenario not applicable. RENEWED 2026-07: verify whether httpcore now allows h11>=0.15 and upgrade instead of renewing again."
     added_at: "2025-09-10"
-    expires_at: "2026-03-31"
+    expires_at: "2026-09-30"
   # Example: Suppress a known false positive
   # "CVE-2023-12345":
   #   reason: "False positive - vulnerability does not affect our usage"

--- a/tests/security/test_pip_audit_suppressions.py
+++ b/tests/security/test_pip_audit_suppressions.py
@@ -1,0 +1,66 @@
+"""Tests for time-boxed vulnerability suppressions (2026-07 security modernization).
+
+Covers tools/security/normalize_pip_audit.py:
+- expires_at is enforced: expired suppressions no longer apply
+- entries without expires_at never expire
+- malformed dates fail safe (suppression stays active, warning emitted)
+"""
+
+import importlib.util
+from datetime import date, timedelta
+from pathlib import Path
+
+import pytest
+
+_MODULE_PATH = Path(__file__).resolve().parents[2] / "tools" / "security" / "normalize_pip_audit.py"
+_spec = importlib.util.spec_from_file_location("normalize_pip_audit", _MODULE_PATH)
+normalize_pip_audit = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(normalize_pip_audit)
+
+
+def _make_project(tmp_path: Path, expires_at: str | None) -> Path:
+    (tmp_path / "requirements.txt").write_text("")  # project-root marker
+    security_dir = tmp_path / "security"
+    security_dir.mkdir()
+    expiry_line = f'    expires_at: "{expires_at}"\n' if expires_at is not None else ""
+    (security_dir / "suppressions.yaml").write_text(
+        "suppressions:\n"
+        '  "GHSA-test-entry":\n'
+        '    reason: "test suppression"\n'
+        '    added_at: "2025-01-01"\n'
+        + expiry_line
+    )
+    return tmp_path
+
+
+_VULN = {"id": "GHSA-test-entry", "cve": "", "package": "pkg", "version": "1.0"}
+
+
+@pytest.mark.ci_safe
+@pytest.mark.unit
+class TestSuppressionExpiry:
+    def test_active_suppression_applies(self, tmp_path):
+        future = (date.today() + timedelta(days=30)).isoformat()
+        root = _make_project(tmp_path, future)
+        assert normalize_pip_audit.is_suppressed(_VULN, project_root=root) is True
+
+    def test_expired_suppression_is_ignored(self, tmp_path, capsys):
+        past = (date.today() - timedelta(days=1)).isoformat()
+        root = _make_project(tmp_path, past)
+        assert normalize_pip_audit.is_suppressed(_VULN, project_root=root) is False
+        assert "expired" in capsys.readouterr().err
+
+    def test_missing_expiry_never_expires(self, tmp_path):
+        root = _make_project(tmp_path, None)
+        assert normalize_pip_audit.is_suppressed(_VULN, project_root=root) is True
+
+    def test_invalid_expiry_fails_safe_as_active(self, tmp_path, capsys):
+        root = _make_project(tmp_path, "not-a-date")
+        assert normalize_pip_audit.is_suppressed(_VULN, project_root=root) is True
+        assert "invalid" in capsys.readouterr().err
+
+    def test_unlisted_vulnerability_not_suppressed(self, tmp_path):
+        future = (date.today() + timedelta(days=30)).isoformat()
+        root = _make_project(tmp_path, future)
+        other = {"id": "GHSA-other", "cve": "", "package": "pkg", "version": "1.0"}
+        assert normalize_pip_audit.is_suppressed(other, project_root=root) is False

--- a/tools/security/normalize_pip_audit.py
+++ b/tools/security/normalize_pip_audit.py
@@ -13,7 +13,7 @@ Usage:
 import json
 import sys
 import argparse
-from datetime import datetime, timezone
+from datetime import date, datetime, timezone
 from typing import Dict, Any, List, Optional
 from pathlib import Path
 import yaml
@@ -121,6 +121,36 @@ def parse_pip_audit_json(data: Dict[str, Any]) -> Dict[str, Any]:
     return report
 
 
+def _suppression_active(suppression: Dict[str, Any]) -> bool:
+    """Return True if a suppression entry is still within its validity window.
+
+    Entries without ``expires_at`` never expire. An expired entry is treated
+    as inactive so the underlying vulnerability resurfaces in the report —
+    suppressions are a time-boxed risk acceptance, not a permanent waiver.
+    """
+    expires_at = suppression.get('expires_at')
+    if not expires_at:
+        return True
+    try:
+        expiry = date.fromisoformat(str(expires_at))
+    except ValueError:
+        print(
+            f"Warning: suppression '{suppression.get('id')}' has invalid "
+            f"expires_at '{expires_at}'; treating as active",
+            file=sys.stderr,
+        )
+        return True
+    if expiry < datetime.now(timezone.utc).date():
+        print(
+            f"Warning: suppression '{suppression.get('id')}' expired on "
+            f"{expiry.isoformat()} and is no longer applied. Re-evaluate the "
+            f"vulnerability or renew the entry in security/suppressions.yaml.",
+            file=sys.stderr,
+        )
+        return False
+    return True
+
+
 def is_suppressed(vulnerability: Dict[str, Any], project_root: Optional[Path] = None) -> bool:
     """Check if a vulnerability should be suppressed based on suppressions.yaml."""
     try:
@@ -157,6 +187,8 @@ def is_suppressed(vulnerability: Dict[str, Any], project_root: Optional[Path] = 
         vuln_version = vulnerability.get('version', '')
 
         for suppression in suppressions:
+            if not _suppression_active(suppression):
+                continue
             sup_id = suppression.get('id')
             # Check by CVE ID
             if sup_id and vuln_cve and sup_id == vuln_cve:


### PR DESCRIPTION
- Add root CLAUDE.md as the single source of truth for coding agents:
  dual-mode (ENABLE_LLM) architecture, prompt-to-execution pipeline,
  llms.txt action types, multi-env config / feature flags, RunContext
  artifact layout, pytest marker discipline, and CI-equivalent test
  commands (BYKILT_ENV unset + ENABLE_LLM=true, -m ci_safe)
- Preserve hard-won testing lessons (Issue #340 patch-scope pitfalls,
  pre-push validation) from the old copilot-instructions
- Add .claude/skills/verify: tiered end-to-end verification workflow
  (targeted tests -> CI simulation -> LLM isolation -> runtime smoke)
- Add .claude/skills/add-llms-action: guide for authoring llms.txt
  actions with type selection, param syntax, validation and smoke tests
- Slim .github/copilot-instructions.md to a pointer at CLAUDE.md plus
  the non-negotiable rules, removing the stale VS Code scaffolding
  checklist

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Fs7hdEUTvyKiFxkFmFWn95